### PR TITLE
API Small テスト ワークフロー: changes と api-small-test ジョブを統合

### DIFF
--- a/.github/workflows/api-small-test.yml
+++ b/.github/workflows/api-small-test.yml
@@ -1,37 +1,15 @@
-name: Go Small テスト
+name: API Small テスト
 
 on:
   pull_request:
     branches: [main]
 
 concurrency:
-  group: go-small-test-${{ github.ref }}
+  group: api-small-test-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    outputs:
-      api: ${{ steps.filter.outputs.api }}
-    steps:
-      - name: リポジトリのチェックアウト
-        uses: actions/checkout@v4
-
-      - name: 変更ファイルのチェック
-        # paths フィルターではなく dorny/paths-filter を使用している理由:
-        # paths フィルターを使うとトリガー自体が発火せず、このワークフローが必須ステータスチェックに
-        # 設定されている場合にマージ不可になるため、ワークフローは常に起動させつつジョブレベルで制御する
-        uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            api:
-              - apps/api/**
-
-  test:
-    needs: changes
-    if: needs.changes.outputs.api == 'true'
+  api-small-test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:
@@ -42,14 +20,26 @@ jobs:
       - name: リポジトリのチェックアウト
         uses: actions/checkout@v4
 
+      - name: 変更ファイルのチェック
+        # paths フィルターではなく dorny/paths-filter を使用している理由:
+        # paths フィルターを使うとトリガー自体が発火せず、このワークフローが必須ステータスチェックに
+        # 設定されている場合にマージ不可になるため、ワークフローは常に起動させつつステップレベルで制御する
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            api:
+              - apps/api/**
+
       - name: Go のセットアップ
+        if: steps.filter.outputs.api == 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: apps/api/go.mod
           cache: true
 
-      - name: 依存関係のダウンロード
-        run: go mod download
-
       - name: Small テストの実行
-        run: go test -skip Medium ./...
+        if: steps.filter.outputs.api == 'true'
+        run: |
+          go mod download
+          go test -skip Medium ./...


### PR DESCRIPTION
## Summary
- `changes` ジョブと `api-small-test` ジョブを1つの `api-small-test` ジョブに統合
- パスフィルタリングをステップレベルで実施し、常にジョブが起動・成功するように変更
- PR マージ条件として `api-small-test` を指定できるようになった

## Detail
### 変更内容
- 2つのジョブを統合することで、`dorny/paths-filter` を使った変更チェックと実装
- APIに変更がない場合、テストステップはスキップされるがジョブは成功
- APIに変更がある場合、テストが実行され、失敗時のみマージ不可

### 背景
従来の `changes` ジョブから `api-small-test` ジョブを依存させる構成では、PR マージ条件として以下の問題がありました：
- `api-small-test` を指定：APIに変更がない場合、ジョブがスキップされマージ不可
- `changes` を指定：テスト失敗時もマージ可能

この問題は、GitHub Actions の必須ステータスチェック機能が「ジョブがスキップされた」と「ジョブが失敗した」を区別するためです。

## Test plan
- [ ] APIに変更がないPRで `api-small-test` ジョブが成功（スキップされず）することを確認
- [ ] APIに変更があるPRでテストが実行され、失敗時にマージ不可になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)