### PR TITLE
マイグレーションチェック用 GitHub Actions ワークフローを追加

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -1,0 +1,57 @@
+name: マイグレーションテスト
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: migration-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  migration-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: リポジトリのチェックアウト
+        uses: actions/checkout@v4
+
+      - name: 変更ファイルのチェック
+        # paths フィルターではなく dorny/paths-filter を使用している理由:
+        # paths フィルターを使うとトリガー自体が発火せず、このワークフローが必須ステータスチェックに
+        # 設定されている場合にマージ不可になるため、ワークフローは常に起動させつつステップレベルで制御する
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            migrations:
+              - apps/api/migrations/**
+
+      - name: golang-migrate のインストール
+        if: steps.filter.outputs.migrations == 'true'
+        run: |
+          curl -L https://github.com/golang-migrate/migrate/releases/download/v4.18.1/migrate.linux-amd64.tar.gz | tar xvz
+          sudo mv migrate /usr/local/bin/migrate
+
+      - name: マイグレーションの実行
+        if: steps.filter.outputs.migrations == 'true'
+        run: |
+          migrate -path apps/api/migrations \
+            -database "postgresql://postgres:password@localhost:5432/postgres?sslmode=disable" \
+            up


### PR DESCRIPTION
## Summary

- `apps/api/migrations/**` が変更された PR でのみ実行されるマイグレーションテストワークフローを追加
- `dorny/paths-filter@v3` でステップレベルのパスフィルタリング（必須チェック設定時のマージ不可問題を回避）
- `services` ブロックで `postgres:18` を起動し、`golang-migrate` でマイグレーションを実行してエラーチェック

## Test plan

- [ ] マイグレーションファイルを変更する PR を作成し、`migration-test` ジョブが成功することを確認
- [ ] マイグレーションファイルを変更しない PR では、インストール・実行ステップがスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)