### PR TITLE
ユーザーのコース受講詳細取得 API を追加

### DIFF
--- a/apps/api/internal/db/enrollments.sql.go
+++ b/apps/api/internal/db/enrollments.sql.go
@@ -11,6 +11,118 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const getCourseAuthorityById = `-- name: GetCourseAuthorityById :one
+SELECT
+    publish_status,
+    author_id
+FROM
+    courses
+WHERE
+    courses.course_id = $1
+`
+
+type GetCourseAuthorityByIdRow struct {
+	PublishStatus string      `json:"publish_status"`
+	AuthorID      pgtype.UUID `json:"author_id"`
+}
+
+func (q *Queries) GetCourseAuthorityById(ctx context.Context, courseid pgtype.UUID) (GetCourseAuthorityByIdRow, error) {
+	row := q.db.QueryRow(ctx, getCourseAuthorityById, courseid)
+	var i GetCourseAuthorityByIdRow
+	err := row.Scan(&i.PublishStatus, &i.AuthorID)
+	return i, err
+}
+
+const getCourseStructureWithProgress = `-- name: GetCourseStructureWithProgress :one
+WITH section_agg AS (
+    SELECT
+        sections.course_id,
+        sections.course_section_id,
+        sections.title,
+        sections.index,
+        COALESCE(
+            jsonb_agg(
+                jsonb_build_object(
+                    'topicId',
+                    topics.course_section_topic_id,
+                    'title',
+                    topics.title,
+                    'status',
+                    COALESCE(progresses.status, 'NOT_STARTED'),
+                    'index',
+                    topics.index
+                )
+                ORDER BY
+                    topics.index
+            ) FILTER (
+                WHERE
+                    topics.course_section_topic_id IS NOT NULL
+            ),
+            '[]' :: jsonb
+        ) AS topics
+    FROM
+        course_sections AS sections
+        LEFT JOIN course_section_topics AS topics ON sections.course_section_id = topics.course_section_id
+        LEFT JOIN user_topic_progresses AS progresses ON progresses.course_section_topic_id = topics.course_section_topic_id
+        AND progresses.user_id = $2
+    WHERE
+        sections.course_id = $1
+    GROUP BY
+        sections.course_id,
+        sections.course_section_id,
+        sections.index,
+        sections.title
+)
+SELECT
+    courses.course_id,
+    courses.title,
+    COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'sectionId',
+                section_agg.course_section_id,
+                'title',
+                section_agg.title,
+                'index',
+                section_agg.index,
+                'topics',
+                section_agg.topics
+            )
+            ORDER BY
+                section_agg.index
+        ) FILTER (
+            WHERE
+                section_agg.course_section_id IS NOT NULL
+        ),
+        '[]' :: jsonb
+    ) :: jsonb AS sections
+FROM
+    courses
+    LEFT JOIN section_agg ON courses.course_id = section_agg.course_id
+WHERE
+    courses.course_id = $1
+GROUP BY
+    courses.course_id
+`
+
+type GetCourseStructureWithProgressParams struct {
+	Courseid pgtype.UUID `json:"courseid"`
+	Userid   pgtype.UUID `json:"userid"`
+}
+
+type GetCourseStructureWithProgressRow struct {
+	CourseID pgtype.UUID `json:"course_id"`
+	Title    string      `json:"title"`
+	Sections []byte      `json:"sections"`
+}
+
+func (q *Queries) GetCourseStructureWithProgress(ctx context.Context, arg GetCourseStructureWithProgressParams) (GetCourseStructureWithProgressRow, error) {
+	row := q.db.QueryRow(ctx, getCourseStructureWithProgress, arg.Courseid, arg.Userid)
+	var i GetCourseStructureWithProgressRow
+	err := row.Scan(&i.CourseID, &i.Title, &i.Sections)
+	return i, err
+}
+
 const getEnrollmentsByUserID = `-- name: GetEnrollmentsByUserID :many
 SELECT
     courses.course_id AS "courseId",
@@ -23,7 +135,8 @@ FROM
 WHERE
     user_topic_progresses.user_id = $1 :: uuid
 GROUP BY
-    courses.course_id, courses.title
+    courses.course_id,
+    courses.title
 ORDER BY
     MAX(user_topic_progresses._updated_at) DESC
 `

--- a/apps/api/internal/db/querier.go
+++ b/apps/api/internal/db/querier.go
@@ -12,7 +12,9 @@ import (
 
 type Querier interface {
 	CountApiKeyByUserID(ctx context.Context, userid pgtype.UUID) (int64, error)
+	GetCourseAuthorityById(ctx context.Context, courseid pgtype.UUID) (GetCourseAuthorityByIdRow, error)
 	GetCourseById(ctx context.Context, courseid pgtype.UUID) (GetCourseByIdRow, error)
+	GetCourseStructureWithProgress(ctx context.Context, arg GetCourseStructureWithProgressParams) (GetCourseStructureWithProgressRow, error)
 	GetCourses(ctx context.Context, arg GetCoursesParams) ([]GetCoursesRow, error)
 	GetEnrollmentsByUserID(ctx context.Context, userid pgtype.UUID) ([]GetEnrollmentsByUserIDRow, error)
 	GetProgressByUserIdAndCourseId(ctx context.Context, arg GetProgressByUserIdAndCourseIdParams) ([]GetProgressByUserIdAndCourseIdRow, error)

--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -41,6 +41,7 @@ func main() {
 		verifier,
 	)
 	getEnrollmentsHandler := enrollmentsqueries.NewGetEnrollmentsHandler(q)
+	getEnrollmentHandler := enrollmentsqueries.NewGetEnrollmentHandler(q)
 
 	http.HandleFunc("GET /v1/courses", coursesHandler.GetCoursesHandler)
 	http.HandleFunc("POST /v1/courses/{courseId}/enrollment", enrollHandler.PostEnrollmentHandler)
@@ -50,6 +51,7 @@ func main() {
 	http.HandleFunc("GET /v1/users/{userID}", getUserHandler.GetUserHandler)
 	http.HandleFunc("PATCH /v1/users/{userID}", updateUserHandler.PatchUserHandler)
 	http.HandleFunc("GET /v1/users/{userID}/enrollments", getEnrollmentsHandler.GetEnrollmentsHandler)
+	http.HandleFunc("GET /v1/users/{userID}/enrollments/{courseId}", getEnrollmentHandler.GetEnrollmentHandler)
 
 	log.Println("Server starting on :8080")
 	log.Fatal(http.ListenAndServe(":8080", nil))

--- a/apps/api/queries/enrollments.sql
+++ b/apps/api/queries/enrollments.sql
@@ -10,6 +10,87 @@ FROM
 WHERE
     user_topic_progresses.user_id = @UserID :: uuid
 GROUP BY
-    courses.course_id, courses.title
+    courses.course_id,
+    courses.title
 ORDER BY
     MAX(user_topic_progresses._updated_at) DESC;
+
+-- name: GetCourseAuthorityById :one
+SELECT
+    publish_status,
+    author_id
+FROM
+    courses
+WHERE
+    courses.course_id = @CourseID;
+
+-- name: GetCourseStructureWithProgress :one
+WITH section_agg AS (
+    SELECT
+        sections.course_id,
+        sections.course_section_id,
+        sections.title,
+        sections.index,
+        COALESCE(
+            jsonb_agg(
+                jsonb_build_object(
+                    'topicId',
+                    topics.course_section_topic_id,
+                    'title',
+                    topics.title,
+                    'status',
+                    COALESCE(progresses.status, 'NOT_STARTED'),
+                    'index',
+                    topics.index
+                )
+                ORDER BY
+                    topics.index
+            ) FILTER (
+                WHERE
+                    topics.course_section_topic_id IS NOT NULL
+            ),
+            '[]' :: jsonb
+        ) AS topics
+    FROM
+        course_sections AS sections
+        LEFT JOIN course_section_topics AS topics ON sections.course_section_id = topics.course_section_id
+        LEFT JOIN user_topic_progresses AS progresses ON progresses.course_section_topic_id = topics.course_section_topic_id
+        AND progresses.user_id = @UserID
+    WHERE
+        sections.course_id = @CourseID
+    GROUP BY
+        sections.course_id,
+        sections.course_section_id,
+        sections.index,
+        sections.title
+)
+SELECT
+    courses.course_id,
+    courses.title,
+    COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'sectionId',
+                section_agg.course_section_id,
+                'title',
+                section_agg.title,
+                'index',
+                section_agg.index,
+                'topics',
+                section_agg.topics
+            )
+            ORDER BY
+                section_agg.index
+        ) FILTER (
+            WHERE
+                section_agg.course_section_id IS NOT NULL
+        ),
+        '[]' :: jsonb
+    ) :: jsonb AS sections
+FROM
+    courses
+    LEFT JOIN section_agg ON courses.course_id = section_agg.course_id
+WHERE
+    courses.course_id = @CourseID
+GROUP BY
+    courses.course_id;

--- a/apps/api/routes/users/enrollments/queries/get-enrollment.query.handler.go
+++ b/apps/api/routes/users/enrollments/queries/get-enrollment.query.handler.go
@@ -1,0 +1,247 @@
+package queries
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+
+	"github.com/harusame0616/ijuku/apps/api/internal/db"
+	"github.com/harusame0616/ijuku/apps/api/lib/response"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+const (
+	progressStatusNotStarted = "NOT_STARTED"
+	progressStatusInProgress = "IN_PROGRESS"
+	progressStatusCompleted  = "COMPLETED"
+	coursePublishStatusPub   = "published"
+
+	errorCodeCourseNotFound     = "COURSE_NOT_FOUND"
+	errorCodeEnrollmentForbidden = "ENROLLMENT_FORBIDDEN"
+)
+
+type GetEnrollmentQuery interface {
+	GetCourseAuthorityById(ctx context.Context, courseid pgtype.UUID) (db.GetCourseAuthorityByIdRow, error)
+	GetCourseStructureWithProgress(ctx context.Context, arg db.GetCourseStructureWithProgressParams) (db.GetCourseStructureWithProgressRow, error)
+}
+
+type GetEnrollmentHandler struct {
+	query GetEnrollmentQuery
+}
+
+func NewGetEnrollmentHandler(q GetEnrollmentQuery) *GetEnrollmentHandler {
+	return &GetEnrollmentHandler{query: q}
+}
+
+// SQL の jsonb 配列をそのまま受ける中間構造体。
+// section_agg / jsonb_build_object のキーと一致させる。
+type rawTopic struct {
+	TopicId string `json:"topicId"`
+	Title   string `json:"title"`
+	Status  string `json:"status"`
+	Index   int    `json:"index"`
+}
+
+type rawSection struct {
+	SectionId string     `json:"sectionId"`
+	Title     string     `json:"title"`
+	Index     int        `json:"index"`
+	Topics    []rawTopic `json:"topics"`
+}
+
+type getEnrollmentTopicResponse struct {
+	TopicId string `json:"topicId"`
+	Title   string `json:"title"`
+	Status  string `json:"status"`
+}
+
+type getEnrollmentSectionResponse struct {
+	SectionId string                       `json:"sectionId"`
+	Title     string                       `json:"title"`
+	Topics    []getEnrollmentTopicResponse `json:"topics"`
+}
+
+type getEnrollmentNextTopicResponse struct {
+	SectionId string `json:"sectionId"`
+	TopicId   string `json:"topicId"`
+}
+
+type GetEnrollmentResponse struct {
+	CourseId  string                          `json:"courseId"`
+	Title     string                          `json:"title"`
+	Sections  []getEnrollmentSectionResponse  `json:"sections"`
+	NextTopic *getEnrollmentNextTopicResponse `json:"nextTopic"`
+}
+
+func (h *GetEnrollmentHandler) GetEnrollmentHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var userID pgtype.UUID
+	if err := userID.Scan(r.PathValue("userID")); err != nil {
+		response.WriteErrorResponse(w, http.StatusBadRequest, response.InputValidationError, "userID must be a valid UUID")
+		return
+	}
+
+	var courseID pgtype.UUID
+	if err := courseID.Scan(r.PathValue("courseId")); err != nil {
+		response.WriteErrorResponse(w, http.StatusBadRequest, response.InputValidationError, "courseId must be a valid UUID")
+		return
+	}
+
+	authority, err := h.query.GetCourseAuthorityById(r.Context(), courseID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			response.WriteErrorResponse(w, http.StatusNotFound, errorCodeCourseNotFound, "course not found")
+			return
+		}
+		log.Printf("GetCourseAuthorityById error: %v", err)
+		response.WriteInternalServerErrorResponse(w)
+		return
+	}
+
+	if authority.PublishStatus != coursePublishStatusPub && authority.AuthorID.Bytes != userID.Bytes {
+		response.WriteErrorResponse(w, http.StatusForbidden, errorCodeEnrollmentForbidden, "this course is not enrollable")
+		return
+	}
+
+	row, err := h.query.GetCourseStructureWithProgress(r.Context(), db.GetCourseStructureWithProgressParams{
+		Courseid: courseID,
+		Userid:   userID,
+	})
+	if err != nil {
+		log.Printf("GetCourseStructureWithProgress error: %v", err)
+		response.WriteInternalServerErrorResponse(w)
+		return
+	}
+
+	rawSections, err := unmarshalSections(row.Sections)
+	if err != nil {
+		log.Printf("unmarshal sections error: %v", err)
+		response.WriteInternalServerErrorResponse(w)
+		return
+	}
+
+	_ = json.NewEncoder(w).Encode(GetEnrollmentResponse{
+		CourseId:  courseID.String(),
+		Title:     row.Title,
+		Sections:  buildSections(rawSections),
+		NextTopic: decideNextTopic(rawSections),
+	})
+}
+
+func unmarshalSections(raw []byte) ([]rawSection, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var sections []rawSection
+	if err := json.Unmarshal(raw, &sections); err != nil {
+		return nil, err
+	}
+	return sections, nil
+}
+
+func buildSections(rawSecs []rawSection) []getEnrollmentSectionResponse {
+	sections := make([]getEnrollmentSectionResponse, 0, len(rawSecs))
+	for _, rs := range rawSecs {
+		topics := make([]getEnrollmentTopicResponse, 0, len(rs.Topics))
+		for _, rt := range rs.Topics {
+			topics = append(topics, getEnrollmentTopicResponse{
+				TopicId: rt.TopicId,
+				Title:   rt.Title,
+				Status:  rt.Status,
+			})
+		}
+		sections = append(sections, getEnrollmentSectionResponse{
+			SectionId: rs.SectionId,
+			Title:     rs.Title,
+			Topics:    topics,
+		})
+	}
+	return sections
+}
+
+// decideNextTopic は section/topic の index ASC 順に並んだ rawSection から、
+// 次に取るべき topic を course.entity.go の findTopicToStart/nextTopic 踏襲で決定する。
+//   - 全 NOT_STARTED                                  -> 先頭トピック
+//   - (sec_idx, top_idx) 最大の非 NOT_STARTED が IN_PROGRESS -> その topic
+//   - 同上が COMPLETED かつ次の topic がある           -> 次の topic
+//   - 同上が COMPLETED かつ最終位置 (= 全完了)         -> nil
+func decideNextTopic(rawSecs []rawSection) *getEnrollmentNextTopicResponse {
+	if len(rawSecs) == 0 {
+		return nil
+	}
+
+	lastSecIdx, lastTopIdx := -1, -1
+	var lastStatus string
+	for si, sec := range rawSecs {
+		for ti, top := range sec.Topics {
+			if top.Status == progressStatusNotStarted {
+				continue
+			}
+			lastSecIdx, lastTopIdx = si, ti
+			lastStatus = top.Status
+		}
+	}
+
+	if lastSecIdx == -1 {
+		return firstTopic(rawSecs)
+	}
+
+	switch lastStatus {
+	case progressStatusInProgress:
+		return topicAt(rawSecs, lastSecIdx, lastTopIdx)
+	case progressStatusCompleted:
+		if nextSec, nextTop, ok := nextPosition(rawSecs, lastSecIdx, lastTopIdx); ok {
+			return topicAt(rawSecs, nextSec, nextTop)
+		}
+		return nil
+	default:
+		return firstTopic(rawSecs)
+	}
+}
+
+// nextPosition は course.entity.go の nextTopic を踏襲。
+// (secIdx, topIdx) が最終位置なら ok=false を返す。
+func nextPosition(rawSecs []rawSection, secIdx, topIdx int) (int, int, bool) {
+	if secIdx < 0 || secIdx >= len(rawSecs) {
+		return 0, 0, false
+	}
+	sec := rawSecs[secIdx]
+	if topIdx < 0 || topIdx >= len(sec.Topics) {
+		return 0, 0, false
+	}
+	if topIdx == len(sec.Topics)-1 {
+		if secIdx == len(rawSecs)-1 {
+			return 0, 0, false
+		}
+		return secIdx + 1, 0, true
+	}
+	return secIdx, topIdx + 1, true
+}
+
+func firstTopic(rawSecs []rawSection) *getEnrollmentNextTopicResponse {
+	if len(rawSecs) == 0 || len(rawSecs[0].Topics) == 0 {
+		return nil
+	}
+	return &getEnrollmentNextTopicResponse{
+		SectionId: rawSecs[0].SectionId,
+		TopicId:   rawSecs[0].Topics[0].TopicId,
+	}
+}
+
+func topicAt(rawSecs []rawSection, secIdx, topIdx int) *getEnrollmentNextTopicResponse {
+	if secIdx < 0 || secIdx >= len(rawSecs) {
+		return nil
+	}
+	sec := rawSecs[secIdx]
+	if topIdx < 0 || topIdx >= len(sec.Topics) {
+		return nil
+	}
+	return &getEnrollmentNextTopicResponse{
+		SectionId: sec.SectionId,
+		TopicId:   sec.Topics[topIdx].TopicId,
+	}
+}

--- a/apps/api/routes/users/enrollments/queries/get-enrollment.query.handler.medium.server_test.go
+++ b/apps/api/routes/users/enrollments/queries/get-enrollment.query.handler.medium.server_test.go
@@ -37,7 +37,7 @@ func insertProgressWithStatus(ctx context.Context, pool *pgxpool.Pool, userID, t
 
 func insertDraftCourse(ctx context.Context, pool *pgxpool.Pool) error {
 	cleanupDraftCourse(ctx, pool)
-	stmts := []struct {
+	statements := []struct {
 		sql  string
 		args []any
 	}{
@@ -56,7 +56,7 @@ func insertDraftCourse(ctx context.Context, pool *pgxpool.Pool) error {
 			[]any{enrollmentDetailDraftTopic, enrollmentDetailDraftCourseID, enrollmentDetailDraftSection},
 		},
 	}
-	for _, s := range stmts {
+	for _, s := range statements {
 		if _, err := pool.Exec(ctx, s.sql, s.args...); err != nil {
 			return err
 		}

--- a/apps/api/routes/users/enrollments/queries/get-enrollment.query.handler.medium.server_test.go
+++ b/apps/api/routes/users/enrollments/queries/get-enrollment.query.handler.medium.server_test.go
@@ -1,0 +1,243 @@
+package queries
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/harusame0616/ijuku/apps/api/internal/db"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	enrollmentDetailDraftCourseID = "24000000-0000-0000-0000-0000000000ff"
+	enrollmentDetailDraftSection  = "25000000-0000-0000-0000-0000000000ff"
+	enrollmentDetailDraftTopic    = "26000000-0000-0000-0000-0000000000ff"
+	enrollmentDetailMissingCourse = "24000000-0000-0000-0000-0000000000ee"
+)
+
+func newGetEnrollmentRequestMedium(t *testing.T, userID, courseID string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/v1/users/"+userID+"/enrollments/"+courseID, nil)
+	req.SetPathValue("userID", userID)
+	req.SetPathValue("courseId", courseID)
+	return req
+}
+
+func insertProgressWithStatus(ctx context.Context, pool *pgxpool.Pool, userID, topicID, status string, updatedAt time.Time) error {
+	_, err := pool.Exec(ctx,
+		`INSERT INTO user_topic_progresses (course_section_topic_id, user_id, status, _updated_at) VALUES ($1, $2, $3, $4)`,
+		topicID, userID, status, updatedAt,
+	)
+	return err
+}
+
+func insertDraftCourse(ctx context.Context, pool *pgxpool.Pool) error {
+	cleanupDraftCourse(ctx, pool)
+	stmts := []struct {
+		sql  string
+		args []any
+	}{
+		{
+			`INSERT INTO courses (course_id, title, description, slug, tags, publish_status, category_id, author_id, visibility)
+			 VALUES ($1, '草稿コース', '', 'enrollments-medium-draft', '[]', 'draft', $2, $3, 'public')`,
+			[]any{enrollmentDetailDraftCourseID, mediumTestCategoryID, mediumTestAuthorID},
+		},
+		{
+			`INSERT INTO course_sections (course_section_id, course_id, index, title, description) VALUES ($1, $2, 0, 'draft section', '')`,
+			[]any{enrollmentDetailDraftSection, enrollmentDetailDraftCourseID},
+		},
+		{
+			`INSERT INTO course_section_topics (course_section_topic_id, course_id, course_section_id, index, title, description, prerequisites, knowledge, flow, quiz, completion_criteria)
+			 VALUES ($1, $2, $3, 0, 'draft topic', '', '', '', '', '', '')`,
+			[]any{enrollmentDetailDraftTopic, enrollmentDetailDraftCourseID, enrollmentDetailDraftSection},
+		},
+	}
+	for _, s := range stmts {
+		if _, err := pool.Exec(ctx, s.sql, s.args...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func cleanupDraftCourse(ctx context.Context, pool *pgxpool.Pool) {
+	_, _ = pool.Exec(ctx, `DELETE FROM user_topic_progresses WHERE course_section_topic_id = $1`, enrollmentDetailDraftTopic)
+	_, _ = pool.Exec(ctx, `DELETE FROM course_section_topics WHERE course_id = $1`, enrollmentDetailDraftCourseID)
+	_, _ = pool.Exec(ctx, `DELETE FROM course_sections WHERE course_id = $1`, enrollmentDetailDraftCourseID)
+	_, _ = pool.Exec(ctx, `DELETE FROM courses WHERE course_id = $1`, enrollmentDetailDraftCourseID)
+}
+
+func TestGetEnrollmentHandlerMedium(t *testing.T) {
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, mediumDatabaseURL())
+	if err != nil {
+		t.Fatalf("DBへの接続に失敗しました: %v", err)
+	}
+	defer pool.Close()
+
+	if err := setupMediumTestData(ctx, pool); err != nil {
+		t.Fatalf("テストデータのセットアップに失敗しました: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupDraftCourse(ctx, pool)
+		cleanupMediumTestData(ctx, pool)
+	})
+
+	handler := NewGetEnrollmentHandler(db.New(pool))
+
+	t.Run("存在しないcourseIdは404を返す", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		handler.GetEnrollmentHandler(w, newGetEnrollmentRequestMedium(t, mediumTestUserID, enrollmentDetailMissingCourse))
+
+		if w.Result().StatusCode != http.StatusNotFound {
+			t.Fatalf("404 を期待: got %d", w.Result().StatusCode)
+		}
+	})
+
+	t.Run("draftコースに非著者でアクセスすると403を返す", func(t *testing.T) {
+		if err := insertDraftCourse(ctx, pool); err != nil {
+			t.Fatalf("draft course 挿入失敗: %v", err)
+		}
+		t.Cleanup(func() { cleanupDraftCourse(ctx, pool) })
+
+		w := httptest.NewRecorder()
+		handler.GetEnrollmentHandler(w, newGetEnrollmentRequestMedium(t, mediumTestUserID, enrollmentDetailDraftCourseID))
+
+		if w.Result().StatusCode != http.StatusForbidden {
+			t.Fatalf("403 を期待: got %d", w.Result().StatusCode)
+		}
+	})
+
+	t.Run("draftコースに著者本人でアクセスすると200を返す", func(t *testing.T) {
+		if err := insertDraftCourse(ctx, pool); err != nil {
+			t.Fatalf("draft course 挿入失敗: %v", err)
+		}
+		t.Cleanup(func() { cleanupDraftCourse(ctx, pool) })
+
+		w := httptest.NewRecorder()
+		handler.GetEnrollmentHandler(w, newGetEnrollmentRequestMedium(t, mediumTestAuthorID, enrollmentDetailDraftCourseID))
+
+		if w.Result().StatusCode != http.StatusOK {
+			t.Fatalf("200 を期待: got %d", w.Result().StatusCode)
+		}
+	})
+
+	t.Run("未受講ユーザーは全statusがnullで先頭トピックがnextTopic", func(t *testing.T) {
+		cleanupMediumProgresses(ctx, pool)
+
+		w := httptest.NewRecorder()
+		handler.GetEnrollmentHandler(w, newGetEnrollmentRequestMedium(t, mediumTestUserID, mediumTestCourseAID))
+
+		if w.Result().StatusCode != http.StatusOK {
+			t.Fatalf("200 を期待: got %d", w.Result().StatusCode)
+		}
+		var body GetEnrollmentResponse
+		if err := json.NewDecoder(w.Result().Body).Decode(&body); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		if len(body.Sections) != 1 || len(body.Sections[0].Topics) != 2 {
+			t.Fatalf("section/topic 構造が期待と異なる: %+v", body.Sections)
+		}
+		for _, topic := range body.Sections[0].Topics {
+			if topic.Status != "NOT_STARTED" {
+				t.Errorf("status は NOT_STARTED であること: got %v", topic.Status)
+			}
+		}
+		if body.NextTopic == nil || body.NextTopic.TopicId == "" {
+			t.Fatalf("nextTopic は先頭トピックを返す: got %+v", body.NextTopic)
+		}
+	})
+
+	t.Run("最新IN_PROGRESSのtopicがnextTopic", func(t *testing.T) {
+		cleanupMediumProgresses(ctx, pool)
+		base := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+		if err := insertProgressWithStatus(ctx, pool, mediumTestUserID, mediumTestTopicA0ID, "COMPLETED", base); err != nil {
+			t.Fatalf("progress 挿入失敗: %v", err)
+		}
+		if err := insertProgressWithStatus(ctx, pool, mediumTestUserID, mediumTestTopicA1ID, "IN_PROGRESS", base.Add(time.Hour)); err != nil {
+			t.Fatalf("progress 挿入失敗: %v", err)
+		}
+
+		w := httptest.NewRecorder()
+		handler.GetEnrollmentHandler(w, newGetEnrollmentRequestMedium(t, mediumTestUserID, mediumTestCourseAID))
+
+		var body GetEnrollmentResponse
+		if err := json.NewDecoder(w.Result().Body).Decode(&body); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		if body.NextTopic == nil {
+			t.Fatalf("nextTopic は IN_PROGRESS トピックを返す")
+		}
+		if body.NextTopic.TopicId != mediumTestTopicA1ID {
+			t.Errorf("nextTopic は A1 を期待: got %s", body.NextTopic.TopicId)
+		}
+	})
+
+	t.Run("最新COMPLETEDかつ次トピックがあればそれをnextTopic", func(t *testing.T) {
+		cleanupMediumProgresses(ctx, pool)
+		base := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+		if err := insertProgressWithStatus(ctx, pool, mediumTestUserID, mediumTestTopicA0ID, "COMPLETED", base); err != nil {
+			t.Fatalf("progress 挿入失敗: %v", err)
+		}
+
+		w := httptest.NewRecorder()
+		handler.GetEnrollmentHandler(w, newGetEnrollmentRequestMedium(t, mediumTestUserID, mediumTestCourseAID))
+
+		var body GetEnrollmentResponse
+		if err := json.NewDecoder(w.Result().Body).Decode(&body); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		if body.NextTopic == nil || body.NextTopic.TopicId != mediumTestTopicA1ID {
+			t.Errorf("nextTopic は A1 を期待: got %+v", body.NextTopic)
+		}
+	})
+
+	t.Run("全COMPLETEDの場合nextTopicはnull", func(t *testing.T) {
+		cleanupMediumProgresses(ctx, pool)
+		base := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+		if err := insertProgressWithStatus(ctx, pool, mediumTestUserID, mediumTestTopicA0ID, "COMPLETED", base); err != nil {
+			t.Fatalf("progress 挿入失敗: %v", err)
+		}
+		if err := insertProgressWithStatus(ctx, pool, mediumTestUserID, mediumTestTopicA1ID, "COMPLETED", base.Add(time.Hour)); err != nil {
+			t.Fatalf("progress 挿入失敗: %v", err)
+		}
+
+		w := httptest.NewRecorder()
+		handler.GetEnrollmentHandler(w, newGetEnrollmentRequestMedium(t, mediumTestUserID, mediumTestCourseAID))
+
+		var body GetEnrollmentResponse
+		if err := json.NewDecoder(w.Result().Body).Decode(&body); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		if body.NextTopic != nil {
+			t.Errorf("nextTopic は null を期待: got %+v", body.NextTopic)
+		}
+	})
+
+	t.Run("他ユーザーの進捗は反映されない", func(t *testing.T) {
+		cleanupMediumProgresses(ctx, pool)
+		base := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+		if err := insertProgressWithStatus(ctx, pool, mediumTestOtherUser, mediumTestTopicA0ID, "IN_PROGRESS", base); err != nil {
+			t.Fatalf("progress 挿入失敗: %v", err)
+		}
+
+		w := httptest.NewRecorder()
+		handler.GetEnrollmentHandler(w, newGetEnrollmentRequestMedium(t, mediumTestUserID, mediumTestCourseAID))
+
+		var body GetEnrollmentResponse
+		if err := json.NewDecoder(w.Result().Body).Decode(&body); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		for _, sec := range body.Sections {
+			for _, tp := range sec.Topics {
+				if tp.Status != "NOT_STARTED" {
+					t.Errorf("対象ユーザーの status は全て NOT_STARTED であること: got %v", tp.Status)
+				}
+			}
+		}
+	})
+}

--- a/apps/api/routes/users/enrollments/queries/get-enrollment.query.handler.small.server_test.go
+++ b/apps/api/routes/users/enrollments/queries/get-enrollment.query.handler.small.server_test.go
@@ -1,0 +1,453 @@
+package queries
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/harusame0616/ijuku/apps/api/internal/db"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	validCourseID   = "00000000-0000-0000-0000-0000000000c0"
+	validAuthorID   = "00000000-0000-0000-0000-0000000000a0"
+	validSection0ID = "00000000-0000-0000-0000-000000000050"
+	validSection1ID = "00000000-0000-0000-0000-000000000051"
+	validTopic00ID  = "00000000-0000-0000-0000-000000000700"
+	validTopic01ID  = "00000000-0000-0000-0000-000000000701"
+	validTopic10ID  = "00000000-0000-0000-0000-000000000710"
+)
+
+type mockGetEnrollmentQuery struct {
+	authority    db.GetCourseAuthorityByIdRow
+	authorityErr error
+	row          db.GetCourseStructureWithProgressRow
+	rowErr       error
+}
+
+func (m *mockGetEnrollmentQuery) GetCourseAuthorityById(_ context.Context, _ pgtype.UUID) (db.GetCourseAuthorityByIdRow, error) {
+	return m.authority, m.authorityErr
+}
+
+func (m *mockGetEnrollmentQuery) GetCourseStructureWithProgress(_ context.Context, _ db.GetCourseStructureWithProgressParams) (db.GetCourseStructureWithProgressRow, error) {
+	return m.row, m.rowErr
+}
+
+func newGetEnrollmentRequest(t *testing.T, userID, courseID string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/v1/users/"+userID+"/enrollments/"+courseID, nil)
+	req.SetPathValue("userID", userID)
+	req.SetPathValue("courseId", courseID)
+	return req
+}
+
+func mustUUID(t *testing.T, s string) pgtype.UUID {
+	t.Helper()
+	var u pgtype.UUID
+	if err := u.Scan(s); err != nil {
+		t.Fatalf("UUID parse failed: %v", err)
+	}
+	return u
+}
+
+func publishedAuthority(t *testing.T) db.GetCourseAuthorityByIdRow {
+	t.Helper()
+	return db.GetCourseAuthorityByIdRow{
+		PublishStatus: "published",
+		AuthorID:      mustUUID(t, validAuthorID),
+	}
+}
+
+func draftAuthorityBy(t *testing.T, authorID string) db.GetCourseAuthorityByIdRow {
+	t.Helper()
+	return db.GetCourseAuthorityByIdRow{
+		PublishStatus: "draft",
+		AuthorID:      mustUUID(t, authorID),
+	}
+}
+
+func sectionsRow(t *testing.T, secs []rawSection) db.GetCourseStructureWithProgressRow {
+	t.Helper()
+	b, err := json.Marshal(secs)
+	if err != nil {
+		t.Fatalf("marshal sections: %v", err)
+	}
+	return db.GetCourseStructureWithProgressRow{Sections: b}
+}
+
+func topic(topicID, title, status string, index int) rawTopic {
+	return rawTopic{TopicId: topicID, Title: title, Status: status, Index: index}
+}
+
+func TestGetEnrollmentHandler_BadRequest(t *testing.T) {
+	t.Run("userIDがUUID形式でない場合400を返す", func(t *testing.T) {
+		h := NewGetEnrollmentHandler(&mockGetEnrollmentQuery{})
+		w := httptest.NewRecorder()
+		h.GetEnrollmentHandler(w, newGetEnrollmentRequest(t, "invalid-uuid", validCourseID))
+
+		assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+		var body map[string]string
+		if err := json.NewDecoder(w.Result().Body).Decode(&body); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		assert.Equal(t, "INPUT_VALIDATION_ERROR", body["errorCode"])
+	})
+
+	t.Run("courseIdがUUID形式でない場合400を返す", func(t *testing.T) {
+		h := NewGetEnrollmentHandler(&mockGetEnrollmentQuery{})
+		w := httptest.NewRecorder()
+		h.GetEnrollmentHandler(w, newGetEnrollmentRequest(t, validUserID, "invalid-uuid"))
+
+		assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+		var body map[string]string
+		if err := json.NewDecoder(w.Result().Body).Decode(&body); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		assert.Equal(t, "INPUT_VALIDATION_ERROR", body["errorCode"])
+	})
+}
+
+func TestGetEnrollmentHandler_Authority(t *testing.T) {
+	t.Run("コースが存在しない場合404を返す", func(t *testing.T) {
+		h := NewGetEnrollmentHandler(&mockGetEnrollmentQuery{authorityErr: pgx.ErrNoRows})
+		w := httptest.NewRecorder()
+		h.GetEnrollmentHandler(w, newGetEnrollmentRequest(t, validUserID, validCourseID))
+
+		assert.Equal(t, http.StatusNotFound, w.Result().StatusCode)
+		var body map[string]string
+		if err := json.NewDecoder(w.Result().Body).Decode(&body); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		assert.Equal(t, "COURSE_NOT_FOUND", body["errorCode"])
+	})
+
+	t.Run("authority取得でDBエラーの場合500を返す", func(t *testing.T) {
+		h := NewGetEnrollmentHandler(&mockGetEnrollmentQuery{authorityErr: errors.New("db error")})
+		w := httptest.NewRecorder()
+		h.GetEnrollmentHandler(w, newGetEnrollmentRequest(t, validUserID, validCourseID))
+
+		assert.Equal(t, http.StatusInternalServerError, w.Result().StatusCode)
+	})
+
+	t.Run("draftコースかつ著者でない場合403を返す", func(t *testing.T) {
+		h := NewGetEnrollmentHandler(&mockGetEnrollmentQuery{authority: draftAuthorityBy(t, validAuthorID)})
+		w := httptest.NewRecorder()
+		h.GetEnrollmentHandler(w, newGetEnrollmentRequest(t, validUserID, validCourseID))
+
+		assert.Equal(t, http.StatusForbidden, w.Result().StatusCode)
+		var body map[string]string
+		if err := json.NewDecoder(w.Result().Body).Decode(&body); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		assert.Equal(t, "ENROLLMENT_FORBIDDEN", body["errorCode"])
+	})
+
+	t.Run("draftコースでも著者本人ならアクセスできる", func(t *testing.T) {
+		h := NewGetEnrollmentHandler(&mockGetEnrollmentQuery{
+			authority: draftAuthorityBy(t, validUserID),
+			row:       sectionsRow(t, []rawSection{}),
+		})
+		w := httptest.NewRecorder()
+		h.GetEnrollmentHandler(w, newGetEnrollmentRequest(t, validUserID, validCourseID))
+
+		assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+	})
+
+	t.Run("structure取得でDBエラーの場合500を返す", func(t *testing.T) {
+		h := NewGetEnrollmentHandler(&mockGetEnrollmentQuery{
+			authority: publishedAuthority(t),
+			rowErr:    errors.New("db error"),
+		})
+		w := httptest.NewRecorder()
+		h.GetEnrollmentHandler(w, newGetEnrollmentRequest(t, validUserID, validCourseID))
+
+		assert.Equal(t, http.StatusInternalServerError, w.Result().StatusCode)
+	})
+
+	t.Run("sections jsonbが不正なJSONの場合500を返す", func(t *testing.T) {
+		h := NewGetEnrollmentHandler(&mockGetEnrollmentQuery{
+			authority: publishedAuthority(t),
+			row:       db.GetCourseStructureWithProgressRow{Sections: []byte("not a json")},
+		})
+		w := httptest.NewRecorder()
+		h.GetEnrollmentHandler(w, newGetEnrollmentRequest(t, validUserID, validCourseID))
+
+		assert.Equal(t, http.StatusInternalServerError, w.Result().StatusCode)
+	})
+}
+
+func TestGetEnrollmentHandler_Response(t *testing.T) {
+	t.Run("sections jsonbが空 (nil) の場合は空sectionsとnextTopic=nullを返す", func(t *testing.T) {
+		h := NewGetEnrollmentHandler(&mockGetEnrollmentQuery{
+			authority: publishedAuthority(t),
+			row:       db.GetCourseStructureWithProgressRow{},
+		})
+		w := httptest.NewRecorder()
+		h.GetEnrollmentHandler(w, newGetEnrollmentRequest(t, validUserID, validCourseID))
+
+		assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+		var body GetEnrollmentResponse
+		if err := json.NewDecoder(w.Result().Body).Decode(&body); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		assert.Equal(t, []getEnrollmentSectionResponse{}, body.Sections)
+		assert.Nil(t, body.NextTopic)
+	})
+
+	t.Run("courseのtitleがレスポンスに含まれる", func(t *testing.T) {
+		h := NewGetEnrollmentHandler(&mockGetEnrollmentQuery{
+			authority: publishedAuthority(t),
+			row:       db.GetCourseStructureWithProgressRow{Title: "テストコース"},
+		})
+		w := httptest.NewRecorder()
+		h.GetEnrollmentHandler(w, newGetEnrollmentRequest(t, validUserID, validCourseID))
+
+		var body GetEnrollmentResponse
+		if err := json.NewDecoder(w.Result().Body).Decode(&body); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		assert.Equal(t, "テストコース", body.Title)
+	})
+
+	t.Run("全NOT_STARTEDなら先頭トピックがnextTopic", func(t *testing.T) {
+		secs := []rawSection{
+			{
+				SectionId: validSection0ID, Title: "S0", Index: 0,
+				Topics: []rawTopic{
+					topic(validTopic00ID, "T0-0", "NOT_STARTED", 0),
+					topic(validTopic01ID, "T0-1", "NOT_STARTED", 1),
+				},
+			},
+		}
+		h := NewGetEnrollmentHandler(&mockGetEnrollmentQuery{
+			authority: publishedAuthority(t),
+			row:       sectionsRow(t, secs),
+		})
+		w := httptest.NewRecorder()
+		h.GetEnrollmentHandler(w, newGetEnrollmentRequest(t, validUserID, validCourseID))
+
+		var body GetEnrollmentResponse
+		if err := json.NewDecoder(w.Result().Body).Decode(&body); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		assert.NotNil(t, body.NextTopic)
+		assert.Equal(t, validSection0ID, body.NextTopic.SectionId)
+		assert.Equal(t, validTopic00ID, body.NextTopic.TopicId)
+		assert.Equal(t, "NOT_STARTED", body.Sections[0].Topics[0].Status)
+	})
+
+	t.Run("最大indexの非NOT_STARTEDがIN_PROGRESSならそのトピック", func(t *testing.T) {
+		secs := []rawSection{
+			{
+				SectionId: validSection0ID, Title: "S0", Index: 0,
+				Topics: []rawTopic{
+					topic(validTopic00ID, "T0-0", "COMPLETED", 0),
+					topic(validTopic01ID, "T0-1", "IN_PROGRESS", 1),
+				},
+			},
+			{
+				SectionId: validSection1ID, Title: "S1", Index: 1,
+				Topics: []rawTopic{
+					topic(validTopic10ID, "T1-0", "NOT_STARTED", 0),
+				},
+			},
+		}
+		h := NewGetEnrollmentHandler(&mockGetEnrollmentQuery{
+			authority: publishedAuthority(t),
+			row:       sectionsRow(t, secs),
+		})
+		w := httptest.NewRecorder()
+		h.GetEnrollmentHandler(w, newGetEnrollmentRequest(t, validUserID, validCourseID))
+
+		var body GetEnrollmentResponse
+		if err := json.NewDecoder(w.Result().Body).Decode(&body); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		assert.Equal(t, validSection0ID, body.NextTopic.SectionId)
+		assert.Equal(t, validTopic01ID, body.NextTopic.TopicId)
+	})
+
+	t.Run("最大indexの非NOT_STARTEDがCOMPLETEDで次があれば次のトピック", func(t *testing.T) {
+		secs := []rawSection{
+			{
+				SectionId: validSection0ID, Title: "S0", Index: 0,
+				Topics: []rawTopic{
+					topic(validTopic00ID, "T0-0", "COMPLETED", 0),
+					topic(validTopic01ID, "T0-1", "NOT_STARTED", 1),
+				},
+			},
+			{
+				SectionId: validSection1ID, Title: "S1", Index: 1,
+				Topics: []rawTopic{
+					topic(validTopic10ID, "T1-0", "NOT_STARTED", 0),
+				},
+			},
+		}
+		h := NewGetEnrollmentHandler(&mockGetEnrollmentQuery{
+			authority: publishedAuthority(t),
+			row:       sectionsRow(t, secs),
+		})
+		w := httptest.NewRecorder()
+		h.GetEnrollmentHandler(w, newGetEnrollmentRequest(t, validUserID, validCourseID))
+
+		var body GetEnrollmentResponse
+		if err := json.NewDecoder(w.Result().Body).Decode(&body); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		assert.Equal(t, validSection0ID, body.NextTopic.SectionId)
+		assert.Equal(t, validTopic01ID, body.NextTopic.TopicId)
+	})
+
+	t.Run("セクション末尾COMPLETEDなら次セクションの先頭トピック", func(t *testing.T) {
+		secs := []rawSection{
+			{
+				SectionId: validSection0ID, Title: "S0", Index: 0,
+				Topics: []rawTopic{
+					topic(validTopic00ID, "T0-0", "COMPLETED", 0),
+				},
+			},
+			{
+				SectionId: validSection1ID, Title: "S1", Index: 1,
+				Topics: []rawTopic{
+					topic(validTopic10ID, "T1-0", "NOT_STARTED", 0),
+				},
+			},
+		}
+		h := NewGetEnrollmentHandler(&mockGetEnrollmentQuery{
+			authority: publishedAuthority(t),
+			row:       sectionsRow(t, secs),
+		})
+		w := httptest.NewRecorder()
+		h.GetEnrollmentHandler(w, newGetEnrollmentRequest(t, validUserID, validCourseID))
+
+		var body GetEnrollmentResponse
+		if err := json.NewDecoder(w.Result().Body).Decode(&body); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		assert.Equal(t, validSection1ID, body.NextTopic.SectionId)
+		assert.Equal(t, validTopic10ID, body.NextTopic.TopicId)
+	})
+
+	t.Run("最終トピックCOMPLETED(全完了)ならnextTopic=null", func(t *testing.T) {
+		secs := []rawSection{
+			{
+				SectionId: validSection0ID, Title: "S0", Index: 0,
+				Topics: []rawTopic{
+					topic(validTopic00ID, "T0-0", "COMPLETED", 0),
+					topic(validTopic01ID, "T0-1", "COMPLETED", 1),
+				},
+			},
+			{
+				SectionId: validSection1ID, Title: "S1", Index: 1,
+				Topics: []rawTopic{
+					topic(validTopic10ID, "T1-0", "COMPLETED", 0),
+				},
+			},
+		}
+		h := NewGetEnrollmentHandler(&mockGetEnrollmentQuery{
+			authority: publishedAuthority(t),
+			row:       sectionsRow(t, secs),
+		})
+		w := httptest.NewRecorder()
+		h.GetEnrollmentHandler(w, newGetEnrollmentRequest(t, validUserID, validCourseID))
+
+		var body GetEnrollmentResponse
+		if err := json.NewDecoder(w.Result().Body).Decode(&body); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		assert.Nil(t, body.NextTopic)
+	})
+
+	t.Run("courseIdとセクション/トピック構造を正しく返す", func(t *testing.T) {
+		secs := []rawSection{
+			{
+				SectionId: validSection0ID, Title: "S0", Index: 0,
+				Topics: []rawTopic{
+					topic(validTopic00ID, "T0-0", "IN_PROGRESS", 0),
+					topic(validTopic01ID, "T0-1", "NOT_STARTED", 1),
+				},
+			},
+			{
+				SectionId: validSection1ID, Title: "S1", Index: 1,
+				Topics: []rawTopic{
+					topic(validTopic10ID, "T1-0", "NOT_STARTED", 0),
+				},
+			},
+		}
+		h := NewGetEnrollmentHandler(&mockGetEnrollmentQuery{
+			authority: publishedAuthority(t),
+			row:       sectionsRow(t, secs),
+		})
+		w := httptest.NewRecorder()
+		h.GetEnrollmentHandler(w, newGetEnrollmentRequest(t, validUserID, validCourseID))
+
+		var body GetEnrollmentResponse
+		if err := json.NewDecoder(w.Result().Body).Decode(&body); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		assert.Equal(t, validCourseID, body.CourseId)
+		assert.Len(t, body.Sections, 2)
+		assert.Equal(t, validSection0ID, body.Sections[0].SectionId)
+		assert.Equal(t, "S0", body.Sections[0].Title)
+		assert.Len(t, body.Sections[0].Topics, 2)
+		assert.Equal(t, "IN_PROGRESS", body.Sections[0].Topics[0].Status)
+		assert.Equal(t, "NOT_STARTED", body.Sections[0].Topics[1].Status)
+		assert.Equal(t, validSection1ID, body.Sections[1].SectionId)
+	})
+}
+
+func TestDecideNextTopic(t *testing.T) {
+	t.Run("rawSecsが空ならnil", func(t *testing.T) {
+		assert.Nil(t, decideNextTopic(nil))
+	})
+
+	t.Run("穴あき: 最大index非NOT_STARTEDが最終COMPLETEDなら全完了扱い (= nil)", func(t *testing.T) {
+		// A0 COMPLETED, A1 NOT_STARTED, B0 COMPLETED (最終)
+		// 最大 index 非 NOT_STARTED = B0 (COMPLETED 最終) -> nil
+		secs := []rawSection{
+			{
+				SectionId: validSection0ID, Title: "S0", Index: 0,
+				Topics: []rawTopic{
+					topic(validTopic00ID, "T0-0", "COMPLETED", 0),
+					topic(validTopic01ID, "T0-1", "NOT_STARTED", 1),
+				},
+			},
+			{
+				SectionId: validSection1ID, Title: "S1", Index: 1,
+				Topics: []rawTopic{
+					topic(validTopic10ID, "T1-0", "COMPLETED", 0),
+				},
+			},
+		}
+		got := decideNextTopic(secs)
+		assert.Nil(t, got)
+	})
+
+	t.Run("穴あき: 最大index非NOT_STARTEDがIN_PROGRESSならそのトピック", func(t *testing.T) {
+		// A0 COMPLETED, A1 IN_PROGRESS, B0 NOT_STARTED
+		secs := []rawSection{
+			{
+				SectionId: validSection0ID, Title: "S0", Index: 0,
+				Topics: []rawTopic{
+					topic(validTopic00ID, "T0-0", "COMPLETED", 0),
+					topic(validTopic01ID, "T0-1", "IN_PROGRESS", 1),
+				},
+			},
+			{
+				SectionId: validSection1ID, Title: "S1", Index: 1,
+				Topics: []rawTopic{
+					topic(validTopic10ID, "T1-0", "NOT_STARTED", 0),
+				},
+			},
+		}
+		got := decideNextTopic(secs)
+		assert.NotNil(t, got)
+		assert.Equal(t, validTopic01ID, got.TopicId)
+	})
+}


### PR DESCRIPTION
## Summary
- `GET /v1/users/{userID}/enrollments/{courseId}` を実装し、指定コースの全セクション・トピック構造に進捗 status と「次に取るべきトピック」を載せて返す
- `nextTopic` 算出は `course.entity.go` の `findTopicToStart`/`nextTopic` を踏襲し、ハンドラ内の純関数 `decideNextTopic` で実装（B チケット側で共通化を検討）
- 認可は `publish_status != 'published' && author_id != userID` を 403、コース未存在を 404、入力不正を 400 として扱う

## ClickUp
- https://app.clickup.com/t/86excxhth

## Test plan
- [ ] `make api-test-all` が pass する
- [ ] `make api-test-coverage` がカバレッジ閾値 (80%) を満たす
- [ ] `make spell-check` が pass する
- [ ] supabase ローカルでマイグレーション後、以下を curl で確認:
  - [ ] 公開コース・未受講ユーザー → 200、各 topic.status=NOT_STARTED、nextTopic=先頭
  - [ ] 進捗 IN_PROGRESS あり → nextTopic=その topic
  - [ ] 最大 index 進捗が COMPLETED → nextTopic=次の topic
  - [ ] 全 COMPLETED → nextTopic=null
  - [ ] 非公開 (draft) コースに非著者でアクセス → 403
  - [ ] 非公開コースに著者本人でアクセス → 200
  - [ ] 存在しない courseId → 404
  - [ ] UUID 不正 (userID/courseId) → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)