### PR TITLE
[86exg0wgf] サービス名を JukuBox.ai から JukuBox に変更

### DIFF
--- a/apps/web/app/(lp)/lp/_components/footer.tsx
+++ b/apps/web/app/(lp)/lp/_components/footer.tsx
@@ -41,7 +41,7 @@ export function Footer(): JSX.Element {
         <Divider />
 
         <p className="font-mono text-xs text-muted-foreground">
-          © 2025 JukuBox.ai — All rights reserved.
+          © 2025 JukuBox — All rights reserved.
         </p>
       </div>
     </footer>

--- a/apps/web/app/(lp)/lp/_components/hero.tsx
+++ b/apps/web/app/(lp)/lp/_components/hero.tsx
@@ -71,9 +71,6 @@ function VinylRecord(): JSX.Element {
           <tspan fill="oklch(0.75 0.12 77)" letterSpacing="1.2">
             JukuBox
           </tspan>
-          <tspan fill="oklch(0.72 0.09 190)" letterSpacing="1.2">
-            .ai
-          </tspan>
         </textPath>
       </text>
       {/* センターホール */}

--- a/apps/web/app/(lp)/privacy-policies/page.tsx
+++ b/apps/web/app/(lp)/privacy-policies/page.tsx
@@ -2,9 +2,9 @@ import type { JSX } from "react";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "プライバシーポリシー | JukuBox.ai",
+  title: "プライバシーポリシー | JukuBox",
   description:
-    "JukuBox.ai のプライバシーポリシー。取得する個人情報等、利用目的、第三者提供、安全管理措置、保存期間、お問い合わせ窓口について記載しています。",
+    "JukuBox のプライバシーポリシー。取得する個人情報等、利用目的、第三者提供、安全管理措置、保存期間、お問い合わせ窓口について記載しています。",
 };
 
 export default function PrivacyPoliciesPage(): JSX.Element {
@@ -14,7 +14,7 @@ export default function PrivacyPoliciesPage(): JSX.Element {
         <h1 className="font-serif text-3xl md:text-4xl">プライバシーポリシー</h1>
         <p className="mt-4 leading-relaxed text-muted-foreground">
           はるさめ dev（以下「当方」といいます。）は、当方が運営する AI 学習プラットフォーム
-          JukuBox.ai（以下「本サービス」といいます。）におけるお客様の個人情報等の取扱いについて、以下のとおりプライバシーポリシー（以下「本ポリシー」といいます。）を定めます。本ポリシーにおいて「個人情報等」とは、個人情報の保護に関する法律（以下「個人情報保護法」といいます。）に定める個人情報及び個人関連情報を総称していいます。
+          JukuBox（以下「本サービス」といいます。）におけるお客様の個人情報等の取扱いについて、以下のとおりプライバシーポリシー（以下「本ポリシー」といいます。）を定めます。本ポリシーにおいて「個人情報等」とは、個人情報の保護に関する法律（以下「個人情報保護法」といいます。）に定める個人情報及び個人関連情報を総称していいます。
         </p>
 
         <h2 className="mt-12 border-b border-border pb-2 font-serif text-xl md:text-2xl">

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -11,7 +11,7 @@ const orbitron = Orbitron({
 });
 
 export const metadata: Metadata = {
-  title: "Jukubox.ai",
+  title: "JukuBox",
   description: "あなたの AI で学ぶ AI 学習プラットフォーム",
 };
 

--- a/apps/web/components/jukubox-logo.tsx
+++ b/apps/web/components/jukubox-logo.tsx
@@ -2,9 +2,9 @@ import type { JSX } from "react";
 import { cn } from "@/lib/utilities";
 
 const sizeMap = {
-  default: { jukubox: "text-xl", dotAi: "text-sm" },
-  lg: { jukubox: "text-3xl", dotAi: "text-lg" },
-  exlg: { jukubox: "text-7xl lg:text-8xl", dotAi: "text-4xl lg:text-5xl" },
+  default: "text-xl",
+  lg: "text-3xl",
+  exlg: "text-7xl lg:text-8xl",
 } as const;
 
 type Size = keyof typeof sizeMap;
@@ -14,19 +14,14 @@ export function JukuBoxLogo({
 }: {
   size?: Size;
 }): JSX.Element {
-  const { jukubox, dotAi } = sizeMap[size];
-
   return (
-    <span className="font-orbitron flex items-baseline gap-0.5">
-      <span
-        className={cn(
-          "text-primary font-black [text-shadow:0_0_18px_oklch(0.75_0.12_77/0.45)]",
-          jukubox,
-        )}
-      >
-        JukuBox
-      </span>
-      <span className={cn("text-secondary font-bold", dotAi)}>.ai</span>
+    <span
+      className={cn(
+        "font-orbitron text-primary font-black [text-shadow:0_0_18px_oklch(0.75_0.12_77/0.45)]",
+        sizeMap[size],
+      )}
+    >
+      JukuBox
     </span>
   );
 }


### PR DESCRIPTION
## Summary

- サービス名を `JukuBox.ai` から `JukuBox` に統一
- ロゴコンポーネント・ルートメタデータ・LP フッター copyright・LP ヒーローの SVG レコード盤ラベル・プライバシーポリシーから `.ai` 表記を削除
- API キープレフィックス `jukubox_`、authorSlug などの識別子・スキル名 `/jukubox` は互換性のため維持

ClickUp: https://app.clickup.com/t/86exg0wgf

## Test plan

- [x] `make web-lint` パス
- [x] `make web-test-all` 106/106 パス、カバレッジ 90.9%
- [x] `make spell-check` Issues 0
- [x] dev サーバーで `/`, `/lp`, `/privacy-policies`, `/courses`, `/login` が 200 応答、`.ai` 表記の残存なしを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)