### PR TITLE
[86exg4xj0] 認証ユーザーとアプリユーザーの紐付け

### DIFF
--- a/apps/api/lib/auth/jwt.go
+++ b/apps/api/lib/auth/jwt.go
@@ -93,12 +93,17 @@ func (v *Verifier) GetUserID(tokenString string) (string, error) {
 		return "", ErrUnauthorized
 	}
 
-	sub, ok := claims["sub"].(string)
-	if !ok || sub == "" {
+	appMetadata, ok := claims["app_metadata"].(map[string]any)
+	if !ok {
 		return "", ErrUnauthorized
 	}
 
-	return sub, nil
+	userID, ok := appMetadata["user_id"].(string)
+	if !ok || userID == "" {
+		return "", ErrUnauthorized
+	}
+
+	return userID, nil
 }
 
 func (v *Verifier) keyFunc(token *jwt.Token) (any, error) {

--- a/apps/api/lib/auth/jwt.small.server_test.go
+++ b/apps/api/lib/auth/jwt.small.server_test.go
@@ -53,29 +53,31 @@ func newVerifierWithEC(t *testing.T, kid string, key *ecdsa.PrivateKey) *auth.Ve
 	return auth.NewVerifier("", srv.URL)
 }
 
-func signHMAC(t *testing.T, secret string, expired bool) string {
+func signHMAC(t *testing.T, secret string, expired bool, userID string) string {
 	t.Helper()
 	exp := time.Now().Add(time.Hour)
 	if expired {
 		exp = time.Now().Add(-time.Hour)
 	}
 	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"sub": "user-id",
-		"exp": exp.Unix(),
+		"sub":          "auth-user-id",
+		"app_metadata": map[string]any{"user_id": userID},
+		"exp":          exp.Unix(),
 	}).SignedString([]byte(secret))
 	require.NoError(t, err)
 	return token
 }
 
-func signEC(t *testing.T, kid string, key *ecdsa.PrivateKey, expired bool) string {
+func signEC(t *testing.T, kid string, key *ecdsa.PrivateKey, expired bool, userID string) string {
 	t.Helper()
 	exp := time.Now().Add(time.Hour)
 	if expired {
 		exp = time.Now().Add(-time.Hour)
 	}
 	tok := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
-		"sub": "user-id",
-		"exp": exp.Unix(),
+		"sub":          "auth-user-id",
+		"app_metadata": map[string]any{"user_id": userID},
+		"exp":          exp.Unix(),
 	})
 	tok.Header["kid"] = kid
 	token, err := tok.SignedString(key)
@@ -83,10 +85,20 @@ func signEC(t *testing.T, kid string, key *ecdsa.PrivateKey, expired bool) strin
 	return token
 }
 
+func signHMACWithClaims(t *testing.T, secret string, claims jwt.MapClaims) string {
+	t.Helper()
+	if _, ok := claims["exp"]; !ok {
+		claims["exp"] = time.Now().Add(time.Hour).Unix()
+	}
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(secret))
+	require.NoError(t, err)
+	return token
+}
+
 func TestVerify(t *testing.T) {
 	t.Run("HMAC署名のトークンが正しい場合、nilを返す", func(t *testing.T) {
 		v := newVerifierWithHMAC(t)
-		token := signHMAC(t, testHMACSecret, false)
+		token := signHMAC(t, testHMACSecret, false, "user-id")
 
 		err := v.Verify(token)
 
@@ -95,7 +107,7 @@ func TestVerify(t *testing.T) {
 
 	t.Run("HMAC署名のトークンが不正な場合、ErrUnauthorizedを返す", func(t *testing.T) {
 		v := newVerifierWithHMAC(t)
-		token := signHMAC(t, "wrong-secret", false)
+		token := signHMAC(t, "wrong-secret", false, "user-id")
 
 		err := v.Verify(token)
 
@@ -104,7 +116,7 @@ func TestVerify(t *testing.T) {
 
 	t.Run("HMACトークンが期限切れの場合、ErrUnauthorizedを返す", func(t *testing.T) {
 		v := newVerifierWithHMAC(t)
-		token := signHMAC(t, testHMACSecret, true)
+		token := signHMAC(t, testHMACSecret, true, "user-id")
 
 		err := v.Verify(token)
 
@@ -116,7 +128,7 @@ func TestVerify(t *testing.T) {
 		require.NoError(t, err)
 		kid := "test-kid"
 		v := newVerifierWithEC(t, kid, key)
-		token := signEC(t, kid, key, false)
+		token := signEC(t, kid, key, false, "user-id")
 
 		err = v.Verify(token)
 
@@ -127,7 +139,7 @@ func TestVerify(t *testing.T) {
 		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 		require.NoError(t, err)
 		v := newVerifierWithEC(t, "registered-kid", key)
-		token := signEC(t, "unknown-kid", key, false)
+		token := signEC(t, "unknown-kid", key, false, "user-id")
 
 		err = v.Verify(token)
 
@@ -138,6 +150,68 @@ func TestVerify(t *testing.T) {
 		v := newVerifierWithHMAC(t)
 
 		err := v.Verify("invalid.token.string")
+
+		assert.ErrorIs(t, err, auth.ErrUnauthorized)
+	})
+}
+
+func TestGetUserID(t *testing.T) {
+	t.Run("app_metadata.user_id を返す", func(t *testing.T) {
+		v := newVerifierWithHMAC(t)
+		token := signHMAC(t, testHMACSecret, false, "01234567-89ab-cdef-0123-456789abcdef")
+
+		userID, err := v.GetUserID(token)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "01234567-89ab-cdef-0123-456789abcdef", userID)
+	})
+
+	t.Run("不正なトークンの場合、ErrUnauthorizedを返す", func(t *testing.T) {
+		v := newVerifierWithHMAC(t)
+
+		_, err := v.GetUserID("invalid.token.string")
+
+		assert.ErrorIs(t, err, auth.ErrUnauthorized)
+	})
+
+	t.Run("app_metadata クレームが無い場合、ErrUnauthorizedを返す", func(t *testing.T) {
+		v := newVerifierWithHMAC(t)
+		token := signHMACWithClaims(t, testHMACSecret, jwt.MapClaims{"sub": "auth-user-id"})
+
+		_, err := v.GetUserID(token)
+
+		assert.ErrorIs(t, err, auth.ErrUnauthorized)
+	})
+
+	t.Run("app_metadata.user_id が無い場合、ErrUnauthorizedを返す", func(t *testing.T) {
+		v := newVerifierWithHMAC(t)
+		token := signHMACWithClaims(t, testHMACSecret, jwt.MapClaims{
+			"sub":          "auth-user-id",
+			"app_metadata": map[string]any{"role": "authenticated"},
+		})
+
+		_, err := v.GetUserID(token)
+
+		assert.ErrorIs(t, err, auth.ErrUnauthorized)
+	})
+
+	t.Run("app_metadata.user_id が空文字の場合、ErrUnauthorizedを返す", func(t *testing.T) {
+		v := newVerifierWithHMAC(t)
+		token := signHMAC(t, testHMACSecret, false, "")
+
+		_, err := v.GetUserID(token)
+
+		assert.ErrorIs(t, err, auth.ErrUnauthorized)
+	})
+
+	t.Run("app_metadata.user_id が string 以外の場合、ErrUnauthorizedを返す", func(t *testing.T) {
+		v := newVerifierWithHMAC(t)
+		token := signHMACWithClaims(t, testHMACSecret, jwt.MapClaims{
+			"sub":          "auth-user-id",
+			"app_metadata": map[string]any{"user_id": 12345},
+		})
+
+		_, err := v.GetUserID(token)
 
 		assert.ErrorIs(t, err, auth.ErrUnauthorized)
 	})

--- a/apps/api/lib/auth/middleware.small.server_test.go
+++ b/apps/api/lib/auth/middleware.small.server_test.go
@@ -54,7 +54,7 @@ func TestMiddleware_NoAuthorizationHeader_Returns401(t *testing.T) {
 
 func TestMiddleware_ValidJWT_PassesUserIDInContext(t *testing.T) {
 	verifier := newVerifierWithHMAC(t)
-	token := signHMAC(t, testHMACSecret, false)
+	token := signHMAC(t, testHMACSecret, false, "user-id")
 	resolver := &stubResolver{}
 
 	captured := ""

--- a/apps/api/migrations/000011_sync_public_users_from_auth.up.sql
+++ b/apps/api/migrations/000011_sync_public_users_from_auth.up.sql
@@ -1,0 +1,54 @@
+CREATE FUNCTION public.handle_new_auth_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    new_user_id UUID := gen_random_uuid();
+BEGIN
+    INSERT INTO public.users (user_id, nickname)
+    VALUES (
+        new_user_id,
+        COALESCE(NEW.raw_user_meta_data->>'name', split_part(NEW.email, '@', 1), 'user')
+    );
+
+    UPDATE auth.users
+    SET raw_app_meta_data = COALESCE(raw_app_meta_data, '{}'::jsonb)
+                          || jsonb_build_object('user_id', new_user_id::text)
+    WHERE id = NEW.id;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trigger_handle_new_auth_user
+    AFTER INSERT ON auth.users
+    FOR EACH ROW
+    EXECUTE FUNCTION public.handle_new_auth_user();
+
+DO $$
+DECLARE
+    rec RECORD;
+    new_user_id UUID;
+BEGIN
+    FOR rec IN
+        SELECT id, raw_user_meta_data, email
+        FROM auth.users
+        WHERE (raw_app_meta_data->>'user_id') IS NULL
+    LOOP
+        new_user_id := gen_random_uuid();
+
+        INSERT INTO public.users (user_id, nickname)
+        VALUES (
+            new_user_id,
+            COALESCE(rec.raw_user_meta_data->>'name', split_part(rec.email, '@', 1), 'user')
+        );
+
+        UPDATE auth.users
+        SET raw_app_meta_data = COALESCE(raw_app_meta_data, '{}'::jsonb)
+                              || jsonb_build_object('user_id', new_user_id::text)
+        WHERE id = rec.id;
+    END LOOP;
+END;
+$$;

--- a/apps/web/lib/test/auth-fixture.ts
+++ b/apps/web/lib/test/auth-fixture.ts
@@ -51,11 +51,16 @@ export const test = base.extend<AuthFixtures>({
         email_confirm: true,
       });
     if (createError) throw createError;
-    const userId = created.user.id;
+    const authUserId = created.user.id;
 
     const { data: signedIn, error: signInError } =
       await anonClient.auth.signInWithPassword({ email, password });
     if (signInError) throw signInError;
+
+    const userId = v.parse(
+      v.pipe(v.string(), v.uuid()),
+      signedIn.session.user.app_metadata.user_id,
+    );
 
     await provide({
       userId,
@@ -65,7 +70,7 @@ export const test = base.extend<AuthFixtures>({
     });
 
     const { error: deleteError } =
-      await adminClient.auth.admin.deleteUser(userId);
+      await adminClient.auth.admin.deleteUser(authUserId);
     if (deleteError) throw deleteError;
   },
 });


### PR DESCRIPTION
## Summary

- OAuth ログイン後に `public.users` が自動作成されず `/settings/profile`（`GET /v1/me`）が 404 になる問題を解消
- `auth.users` への `AFTER INSERT` トリガーで `public.users` を自動作成し、 独立した `user_id`（`gen_random_uuid()`）を発行して `auth.users.raw_app_meta_data` に書き込む
- API の JWT 検証を `claims.sub` 直読みから `claims.app_metadata.user_id` 経路に切り替え（`auth.users.id` ≠ `public.users.user_id` の独立 ID 設計に移行）

## 変更内容

### 新規

- `apps/api/migrations/000010_sync_public_users_from_auth.up.sql`
  - `public.handle_new_auth_user()`（`SECURITY DEFINER`, `search_path = public, pg_temp` 固定）
  - `auth.users` への `AFTER INSERT FOR EACH ROW` トリガー
  - 既存 `auth.users` への backfill（`raw_app_meta_data.user_id` 未設定のものに対応）

### 修正

- `apps/api/lib/auth/jwt.go` — `GetUserID` を `app_metadata.user_id` 経路に変更（`sub` フォールバック廃止）
- `apps/api/lib/auth/jwt.small.server_test.go` — `signHMAC`/`signEC` を `app_metadata.user_id` 込みで署名できるよう拡張、 `TestGetUserID` を追加（正常系・`app_metadata` 欠落・`user_id` 欠落・空文字・型不一致）
- `apps/api/lib/auth/middleware.small.server_test.go` — `signHMAC` 新シグネチャ追従
- `apps/web/lib/test/auth-fixture.ts` — `provide` する `userId` を `session.user.app_metadata.user_id` から取得し、 cleanup の `deleteUser` には `auth.users.id` を渡す

### 修正不要

- handler 群（`UserIDFromContext` 経由のため自動追従）
- 既存 medium テストの `INSERT INTO users` 直書き（`auth.users` を介さない単独 INSERT のため）
- フロントの `auth/callback`（トリガーで自動同期されるため追加 fetch 不要）

## スコープアウト

- `public.authors` の自動作成（コース作成機能で対応する別チケット）
- RLS / GRANT 整理（`SECURITY DEFINER` で逃げる）
- 本番 backfill 戦略（本番未リリース前提のため migration 内 backfill で完了）

## Test plan

- [x] `make db-reset` でマイグレーション通過（`10/u sync_public_users_from_auth` 適用）
- [x] seed 後の `auth.users` で `raw_app_meta_data.user_id` が設定され、 `public.users` に対応レコードが生成されていること
- [x] 新規 `auth.users` INSERT でトリガーが発火して `public.users` 行と `app_metadata.user_id` が同期されること
- [x] `make api-test-all` 全 pass
- [x] `make web-test-all` 全 pass（93/93）
- [x] `curl GET /v1/me`（`signInWithPassword` で取得した access_token）で 200 / `nickname` が取得できる
- [x] `curl PATCH /v1/me` で nickname/introduce 更新後、再取得で更新値が返る
- [ ] ブラウザで OAuth ログイン → `/settings/profile` が 200 表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)