### PR TITLE
[86excr3rj] API キー削除機能実装

### DIFF
--- a/.cspell.yaml
+++ b/.cspell.yaml
@@ -65,6 +65,7 @@ words:
   - sqls
   - sqrc
   - Sqrc
+  - execrows
   # postgresql types / terms
   - pgconn
   - pgtype

--- a/apps/api/internal/db/apikeys.sql.go
+++ b/apps/api/internal/db/apikeys.sql.go
@@ -27,6 +27,27 @@ func (q *Queries) CountApiKeyByUserID(ctx context.Context, userid pgtype.UUID) (
 	return count, err
 }
 
+const deleteApiKeyByID = `-- name: DeleteApiKeyByID :execrows
+DELETE FROM
+    apikeys
+WHERE
+    apikeys.apikey_id = $1 :: uuid
+    AND apikeys.user_id = $2 :: uuid
+`
+
+type DeleteApiKeyByIDParams struct {
+	ApikeyID pgtype.UUID `json:"apikey_id"`
+	UserID   pgtype.UUID `json:"user_id"`
+}
+
+func (q *Queries) DeleteApiKeyByID(ctx context.Context, arg DeleteApiKeyByIDParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteApiKeyByID, arg.ApikeyID, arg.UserID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const getUserIDByApiKeyHash = `-- name: GetUserIDByApiKeyHash :one
 SELECT
     user_id

--- a/apps/api/internal/db/querier.go
+++ b/apps/api/internal/db/querier.go
@@ -12,6 +12,7 @@ import (
 
 type Querier interface {
 	CountApiKeyByUserID(ctx context.Context, userid pgtype.UUID) (int64, error)
+	DeleteApiKeyByID(ctx context.Context, arg DeleteApiKeyByIDParams) (int64, error)
 	GetCourseAuthorityById(ctx context.Context, courseid pgtype.UUID) (GetCourseAuthorityByIdRow, error)
 	GetCourseById(ctx context.Context, courseid pgtype.UUID) (GetCourseByIdRow, error)
 	GetCourseBySlug(ctx context.Context, arg GetCourseBySlugParams) (GetCourseBySlugRow, error)

--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -37,8 +37,10 @@ func main() {
 	enrollHandler := enrollmentscommands.NewEnrollHandler(enrollmentscommands.NewEnrollUsecase(courseRepo, enrollmentRepo))
 	topicDetailHandler := queries.NewTopicDetailHandler(q)
 	verifier := libauth.NewVerifier(env.Require("SUPABASE_JWT_SECRET"), env.Require("SUPABASE_URL"))
-	apikeysHandler := apikeys.NewGenerateApiKeyHandler(apikeys.NewGenerateApiKeyUsecase(apikeys.NewApiKeySqrcRepository(), txrunner.NewPgxTransactionRunner(pool)))
+	apiKeyRepo := apikeys.NewApiKeySqrcRepository(q)
+	apikeysHandler := apikeys.NewGenerateApiKeyHandler(apikeys.NewGenerateApiKeyUsecase(apiKeyRepo, txrunner.NewPgxTransactionRunner(pool)))
 	listApiKeysHandler := apikeys.NewListApiKeysHandler(q)
+	deleteApiKeyHandler := apikeys.NewDeleteApiKeyHandler(apikeys.NewDeleteApiKeyUsecase(apiKeyRepo))
 
 	getUserHandler := usersqueries.NewGetUserHandler(q)
 	updateUserHandler := userscommands.NewUpdateUserHandler(
@@ -62,6 +64,7 @@ func main() {
 	http.Handle("PATCH /v1/me", authMiddleware(http.HandlerFunc(updateUserHandler.PatchUserHandler)))
 	http.Handle("POST /v1/me/apikeys", authMiddleware(http.HandlerFunc(apikeysHandler.GenerateApiKeyHandler)))
 	http.Handle("GET /v1/me/settings/apikeys", authMiddleware(http.HandlerFunc(listApiKeysHandler.ListApiKeysHandler)))
+	http.Handle("DELETE /v1/me/apikeys/{apikeyID}", authMiddleware(http.HandlerFunc(deleteApiKeyHandler.DeleteApiKeyHandler)))
 	http.Handle("GET /v1/me/enrollments", authMiddleware(http.HandlerFunc(getEnrollmentsHandler.GetEnrollmentsHandler)))
 	http.Handle("GET /v1/me/enrollments/{courseId}", authMiddleware(http.HandlerFunc(getEnrollmentHandler.GetEnrollmentHandler)))
 	http.Handle("POST /v1/me/enrollments", authMiddleware(http.HandlerFunc(enrollHandler.PostEnrollmentHandler)))

--- a/apps/api/queries/apikeys.sql
+++ b/apps/api/queries/apikeys.sql
@@ -35,6 +35,13 @@ FROM
 WHERE
     apikeys.user_id = @UserID :: uuid;
 
+-- name: DeleteApiKeyByID :execrows
+DELETE FROM
+    apikeys
+WHERE
+    apikeys.apikey_id = @apikey_id :: uuid
+    AND apikeys.user_id = @user_id :: uuid;
+
 -- name: GetUserIDByApiKeyHash :one
 SELECT
     user_id

--- a/apps/api/routes/users/settings/apikeys/api-key.sqrc-repository.go
+++ b/apps/api/routes/users/settings/apikeys/api-key.sqrc-repository.go
@@ -9,10 +9,16 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-type ApiKeySqrcRepository struct{}
+type apiKeyQuerier interface {
+	DeleteApiKeyByID(ctx context.Context, arg db.DeleteApiKeyByIDParams) (int64, error)
+}
 
-func NewApiKeySqrcRepository() ApiKeySqrcRepository {
-	return ApiKeySqrcRepository{}
+type ApiKeySqrcRepository struct {
+	q apiKeyQuerier
+}
+
+func NewApiKeySqrcRepository(q apiKeyQuerier) ApiKeySqrcRepository {
+	return ApiKeySqrcRepository{q: q}
 }
 
 func (repo ApiKeySqrcRepository) countWithTx(ctx context.Context, tx pgx.Tx, userId uuid.UUID) int {
@@ -24,6 +30,13 @@ func (repo ApiKeySqrcRepository) countWithTx(ctx context.Context, tx pgx.Tx, use
 		return 0
 	}
 	return int(count)
+}
+
+func (repo ApiKeySqrcRepository) deleteByID(ctx context.Context, userID, apiKeyID uuid.UUID) (int64, error) {
+	return repo.q.DeleteApiKeyByID(ctx, db.DeleteApiKeyByIDParams{
+		ApikeyID: pgtype.UUID{Bytes: apiKeyID, Valid: true},
+		UserID:   pgtype.UUID{Bytes: userID, Valid: true},
+	})
 }
 
 func (repo ApiKeySqrcRepository) saveWithTx(ctx context.Context, tx pgx.Tx, apiKey hashedApiKey) error {

--- a/apps/api/routes/users/settings/apikeys/delete-api-key.command.handler.go
+++ b/apps/api/routes/users/settings/apikeys/delete-api-key.command.handler.go
@@ -1,0 +1,57 @@
+package apikeys
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/google/uuid"
+	libauth "github.com/harusame0616/ijuku/apps/api/lib/auth"
+	"github.com/harusame0616/ijuku/apps/api/lib/response"
+)
+
+type deleteApiKeyExecutor interface {
+	Execute(ctx context.Context, userID, apiKeyID uuid.UUID) error
+}
+
+type DeleteApiKeyHandler struct {
+	usecase deleteApiKeyExecutor
+}
+
+func NewDeleteApiKeyHandler(usecase deleteApiKeyExecutor) *DeleteApiKeyHandler {
+	return &DeleteApiKeyHandler{usecase: usecase}
+}
+
+func (h *DeleteApiKeyHandler) DeleteApiKeyHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	userIDStr, ok := libauth.UserIDFromContext(r.Context())
+	if !ok {
+		response.WriteErrorResponse(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized")
+		return
+	}
+
+	userID, err := uuid.Parse(userIDStr)
+	if err != nil {
+		response.WriteErrorResponse(w, http.StatusBadRequest, response.InputValidationError, "userID must be a valid UUID")
+		return
+	}
+
+	apiKeyID, err := uuid.Parse(r.PathValue("apikeyID"))
+	if err != nil {
+		response.WriteErrorResponse(w, http.StatusBadRequest, response.InputValidationError, "apikeyID must be a valid UUID")
+		return
+	}
+
+	if err := h.usecase.Execute(r.Context(), userID, apiKeyID); err != nil {
+		switch {
+		case errors.Is(err, ErrApiKeyNotFound):
+			response.WriteErrorResponse(w, http.StatusNotFound, "APIKEY_NOT_FOUND", "api key not found")
+		default:
+			response.WriteInternalServerErrorResponse(w)
+		}
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/apps/api/routes/users/settings/apikeys/delete-api-key.command.handler.medium.server_test.go
+++ b/apps/api/routes/users/settings/apikeys/delete-api-key.command.handler.medium.server_test.go
@@ -1,0 +1,100 @@
+package apikeys_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/harusame0616/ijuku/apps/api/internal/db"
+	libauth "github.com/harusame0616/ijuku/apps/api/lib/auth"
+	"github.com/harusame0616/ijuku/apps/api/lib/env"
+	"github.com/harusame0616/ijuku/apps/api/lib/uuidutils"
+	"github.com/harusame0616/ijuku/apps/api/routes/users/settings/apikeys"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteApiKeyHandlerMedium(t *testing.T) {
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, env.Require("DATABASE_URL"))
+	if err != nil {
+		t.Fatalf("DBへの接続に失敗しました: %v", err)
+	}
+	defer pool.Close()
+
+	q := db.New(pool)
+	handler := apikeys.NewDeleteApiKeyHandler(apikeys.NewDeleteApiKeyUsecase(apikeys.NewApiKeySqrcRepository(q)))
+
+	newAuthorizedRequest := func(t *testing.T, userID, apiKeyID string) *http.Request {
+		t.Helper()
+		r := httptest.NewRequest(http.MethodDelete, "/v1/me/apikeys/"+apiKeyID, nil)
+		r.SetPathValue("apikeyID", apiKeyID)
+		r = r.WithContext(libauth.WithUserID(r.Context(), userID))
+		return r
+	}
+
+	t.Run("自分の API キーを削除できる", func(t *testing.T) {
+		userID := uuidutils.MustNewUuidString()
+		require.NoError(t, insertUser(ctx, pool, userID))
+		t.Cleanup(func() {
+			cleanupApiKeys(ctx, pool, userID)
+			cleanupUser(ctx, pool, userID)
+		})
+		apiKeyID := uuidutils.MustNewUuidString()
+		_, err := pool.Exec(ctx, `INSERT INTO apikeys (apikey_id, user_id, key_hash, plain_suffix, expired_at) VALUES ($1, $2, $3, 'suffix', 'infinity')`,
+			apiKeyID, userID, uuidutils.MustNewUuidString())
+		require.NoError(t, err)
+
+		w := httptest.NewRecorder()
+		handler.DeleteApiKeyHandler(w, newAuthorizedRequest(t, userID, apiKeyID))
+
+		assert.Equal(t, http.StatusNoContent, w.Result().StatusCode)
+
+		var count int
+		require.NoError(t, pool.QueryRow(ctx, `SELECT COUNT(*) FROM apikeys WHERE apikey_id = $1`, apiKeyID).Scan(&count))
+		assert.Equal(t, 0, count)
+	})
+
+	t.Run("他人の API キーは削除されず 404 を返す", func(t *testing.T) {
+		ownerID := uuidutils.MustNewUuidString()
+		otherID := uuidutils.MustNewUuidString()
+		require.NoError(t, insertUser(ctx, pool, ownerID))
+		require.NoError(t, insertUser(ctx, pool, otherID))
+		t.Cleanup(func() {
+			cleanupApiKeys(ctx, pool, ownerID)
+			cleanupUser(ctx, pool, ownerID)
+			cleanupUser(ctx, pool, otherID)
+		})
+		apiKeyID := uuidutils.MustNewUuidString()
+		_, err := pool.Exec(ctx, `INSERT INTO apikeys (apikey_id, user_id, key_hash, plain_suffix, expired_at) VALUES ($1, $2, $3, 'suffix', 'infinity')`,
+			apiKeyID, ownerID, uuidutils.MustNewUuidString())
+		require.NoError(t, err)
+
+		w := httptest.NewRecorder()
+		handler.DeleteApiKeyHandler(w, newAuthorizedRequest(t, otherID, apiKeyID))
+
+		assert.Equal(t, http.StatusNotFound, w.Result().StatusCode)
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(w.Result().Body).Decode(&body))
+		assert.Equal(t, "APIKEY_NOT_FOUND", body["errorCode"])
+
+		var count int
+		require.NoError(t, pool.QueryRow(ctx, `SELECT COUNT(*) FROM apikeys WHERE apikey_id = $1`, apiKeyID).Scan(&count))
+		assert.Equal(t, 1, count)
+	})
+
+	t.Run("存在しない API キー ID の場合 404 を返す", func(t *testing.T) {
+		userID := uuidutils.MustNewUuidString()
+		require.NoError(t, insertUser(ctx, pool, userID))
+		t.Cleanup(func() { cleanupUser(ctx, pool, userID) })
+
+		w := httptest.NewRecorder()
+		handler.DeleteApiKeyHandler(w, newAuthorizedRequest(t, userID, uuidutils.MustNewUuidString()))
+
+		assert.Equal(t, http.StatusNotFound, w.Result().StatusCode)
+	})
+}

--- a/apps/api/routes/users/settings/apikeys/delete-api-key.command.handler.small.server_test.go
+++ b/apps/api/routes/users/settings/apikeys/delete-api-key.command.handler.small.server_test.go
@@ -1,0 +1,87 @@
+package apikeys
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	libauth "github.com/harusame0616/ijuku/apps/api/lib/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockDeleteApiKeyExecutor struct {
+	err error
+}
+
+func (m *mockDeleteApiKeyExecutor) Execute(_ context.Context, _, _ uuid.UUID) error {
+	return m.err
+}
+
+func newDeleteRequest(t *testing.T, userID, apiKeyID string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodDelete, "/v1/me/apikeys/"+apiKeyID, nil)
+	req.SetPathValue("apikeyID", apiKeyID)
+	if userID != "" {
+		req = req.WithContext(libauth.WithUserID(req.Context(), userID))
+	}
+	return req
+}
+
+func TestDeleteApiKeyHandler(t *testing.T) {
+	const validApiKeyID = "11111111-1111-1111-1111-111111111111"
+
+	t.Run("認証情報が無い場合401を返す", func(t *testing.T) {
+		h := NewDeleteApiKeyHandler(&mockDeleteApiKeyExecutor{})
+		w := httptest.NewRecorder()
+		h.DeleteApiKeyHandler(w, newDeleteRequest(t, "", validApiKeyID))
+		assert.Equal(t, http.StatusUnauthorized, w.Result().StatusCode)
+	})
+
+	t.Run("userIDがUUID形式でない場合400を返す", func(t *testing.T) {
+		h := NewDeleteApiKeyHandler(&mockDeleteApiKeyExecutor{})
+		w := httptest.NewRecorder()
+		h.DeleteApiKeyHandler(w, newDeleteRequest(t, "not-a-uuid", validApiKeyID))
+		assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+	})
+
+	t.Run("apikeyIDがUUID形式でない場合400を返す", func(t *testing.T) {
+		h := NewDeleteApiKeyHandler(&mockDeleteApiKeyExecutor{})
+		w := httptest.NewRecorder()
+		h.DeleteApiKeyHandler(w, newDeleteRequest(t, testUserID, "not-a-uuid"))
+		assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(w.Result().Body).Decode(&body))
+		assert.Equal(t, "INPUT_VALIDATION_ERROR", body["errorCode"])
+	})
+
+	t.Run("該当キーが無い場合404を返す", func(t *testing.T) {
+		h := NewDeleteApiKeyHandler(&mockDeleteApiKeyExecutor{err: ErrApiKeyNotFound})
+		w := httptest.NewRecorder()
+		h.DeleteApiKeyHandler(w, newDeleteRequest(t, testUserID, validApiKeyID))
+		assert.Equal(t, http.StatusNotFound, w.Result().StatusCode)
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(w.Result().Body).Decode(&body))
+		assert.Equal(t, "APIKEY_NOT_FOUND", body["errorCode"])
+	})
+
+	t.Run("usecaseが想定外のエラーの場合500を返す", func(t *testing.T) {
+		h := NewDeleteApiKeyHandler(&mockDeleteApiKeyExecutor{err: errors.New("unexpected")})
+		w := httptest.NewRecorder()
+		h.DeleteApiKeyHandler(w, newDeleteRequest(t, testUserID, validApiKeyID))
+		assert.Equal(t, http.StatusInternalServerError, w.Result().StatusCode)
+	})
+
+	t.Run("正常系では204を返す", func(t *testing.T) {
+		h := NewDeleteApiKeyHandler(&mockDeleteApiKeyExecutor{})
+		w := httptest.NewRecorder()
+		h.DeleteApiKeyHandler(w, newDeleteRequest(t, testUserID, validApiKeyID))
+		assert.Equal(t, http.StatusNoContent, w.Result().StatusCode)
+	})
+}

--- a/apps/api/routes/users/settings/apikeys/delete-api-key.usecase.go
+++ b/apps/api/routes/users/settings/apikeys/delete-api-key.usecase.go
@@ -1,0 +1,33 @@
+package apikeys
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+)
+
+var ErrApiKeyNotFound = errors.New("api key not found")
+
+type deleteApiKeyRepository interface {
+	deleteByID(ctx context.Context, userID, apiKeyID uuid.UUID) (int64, error)
+}
+
+type deleteApiKeyUsecase struct {
+	repository deleteApiKeyRepository
+}
+
+func NewDeleteApiKeyUsecase(repository deleteApiKeyRepository) *deleteApiKeyUsecase {
+	return &deleteApiKeyUsecase{repository: repository}
+}
+
+func (u *deleteApiKeyUsecase) Execute(ctx context.Context, userID, apiKeyID uuid.UUID) error {
+	rows, err := u.repository.deleteByID(ctx, userID, apiKeyID)
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return ErrApiKeyNotFound
+	}
+	return nil
+}

--- a/apps/api/routes/users/settings/apikeys/delete-api-key.usecase.small.server_test.go
+++ b/apps/api/routes/users/settings/apikeys/delete-api-key.usecase.small.server_test.go
@@ -1,0 +1,52 @@
+package apikeys
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockDeleteApiKeyRepository struct {
+	rows         int64
+	err          error
+	gotUserID    uuid.UUID
+	gotApiKeyID  uuid.UUID
+	deleteCalled bool
+}
+
+func (m *mockDeleteApiKeyRepository) deleteByID(_ context.Context, userID, apiKeyID uuid.UUID) (int64, error) {
+	m.deleteCalled = true
+	m.gotUserID = userID
+	m.gotApiKeyID = apiKeyID
+	return m.rows, m.err
+}
+
+func TestDeleteApiKeyUsecaseExecute(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	apiKeyID := uuid.New()
+
+	t.Run("リポジトリがエラーを返した場合エラーを伝搬する", func(t *testing.T) {
+		repoErr := errors.New("db error")
+		usecase := NewDeleteApiKeyUsecase(&mockDeleteApiKeyRepository{err: repoErr})
+		assert.ErrorIs(t, usecase.Execute(ctx, userID, apiKeyID), repoErr)
+	})
+
+	t.Run("削除対象が無い場合 ErrApiKeyNotFound を返す", func(t *testing.T) {
+		usecase := NewDeleteApiKeyUsecase(&mockDeleteApiKeyRepository{rows: 0})
+		assert.ErrorIs(t, usecase.Execute(ctx, userID, apiKeyID), ErrApiKeyNotFound)
+	})
+
+	t.Run("削除に成功した場合 nil を返し、 user_id と apikey_id がリポジトリに渡る", func(t *testing.T) {
+		repo := &mockDeleteApiKeyRepository{rows: 1}
+		usecase := NewDeleteApiKeyUsecase(repo)
+		require.NoError(t, usecase.Execute(ctx, userID, apiKeyID))
+		assert.True(t, repo.deleteCalled)
+		assert.Equal(t, userID, repo.gotUserID)
+		assert.Equal(t, apiKeyID, repo.gotApiKeyID)
+	})
+}

--- a/apps/api/routes/users/settings/apikeys/generate-apikey.command.handler.medium.server_test.go
+++ b/apps/api/routes/users/settings/apikeys/generate-apikey.command.handler.medium.server_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/harusame0616/ijuku/apps/api/internal/db"
 	libauth "github.com/harusame0616/ijuku/apps/api/lib/auth"
 	"github.com/harusame0616/ijuku/apps/api/lib/env"
 	"github.com/harusame0616/ijuku/apps/api/lib/txrunner"
@@ -27,7 +28,8 @@ func TestGenerateApiKeyHandlerMedium(t *testing.T) {
 	}
 	defer pool.Close()
 
-	handler := apikeys.NewGenerateApiKeyHandler(apikeys.NewGenerateApiKeyUsecase(apikeys.NewApiKeySqrcRepository(), txrunner.NewPgxTransactionRunner(pool)))
+	q := db.New(pool)
+	handler := apikeys.NewGenerateApiKeyHandler(apikeys.NewGenerateApiKeyUsecase(apikeys.NewApiKeySqrcRepository(q), txrunner.NewPgxTransactionRunner(pool)))
 
 	newAuthorizedRequest := func(t *testing.T, userID, body string) *http.Request {
 		t.Helper()

--- a/apps/web/app/(main)/settings/api-keys/api-keys-list.presenter.client.test.tsx
+++ b/apps/web/app/(main)/settings/api-keys/api-keys-list.presenter.client.test.tsx
@@ -1,6 +1,10 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { render } from "vitest-browser-react";
 import { ApiKeysListPresenter } from "./api-keys-list.presenter.client";
+
+vi.mock("./delete-api-key.action", () => ({
+  deleteApiKey: async () => ({ success: true }),
+}));
 
 test("0 件の場合は空状態メッセージを表示する", async () => {
   const screen = await render(<ApiKeysListPresenter apiKeys={[]} />);
@@ -62,4 +66,23 @@ test("disabled=true の場合はテーブルヘッダーが表示され、空状
   await expect
     .element(screen.getByText("API キーがまだ登録されていません。"))
     .not.toBeInTheDocument();
+});
+
+test("各行に削除ボタンが表示される", async () => {
+  const screen = await render(
+    <ApiKeysListPresenter
+      apiKeys={[
+        {
+          apiKeyId: "id-1",
+          suffix: "a3f9",
+          createdAt: "2026-01-10T00:00:00Z",
+          expiredAt: null,
+        },
+      ]}
+    />,
+  );
+
+  await expect
+    .element(screen.getByRole("button", { name: "削除" }))
+    .toBeVisible();
 });

--- a/apps/web/app/(main)/settings/api-keys/api-keys-list.presenter.client.tsx
+++ b/apps/web/app/(main)/settings/api-keys/api-keys-list.presenter.client.tsx
@@ -1,6 +1,18 @@
 "use client";
 
-import type { JSX } from "react";
+import { type JSX, useState, useTransition } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Table,
@@ -10,6 +22,10 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  type DeleteApiKeyErrorCode,
+  deleteApiKey,
+} from "./delete-api-key.action";
 import type { ApiKey } from "./api-keys.data";
 
 const API_KEY_MASK = "jukubox_••••";
@@ -17,6 +33,14 @@ const API_KEY_MASK = "jukubox_••••";
 const dateFormatter = new Intl.DateTimeFormat("ja-JP", {
   dateStyle: "medium",
 });
+
+const deleteErrorMessages: Record<DeleteApiKeyErrorCode, string> = {
+  UNAUTHORIZED: "認証が切れています。再度ログインしてください。",
+  APIKEY_NOT_FOUND:
+    "対象の API キーが見つかりませんでした。一覧を更新してください。",
+  INTERNAL_ERROR:
+    "予期しないエラーが発生しました。時間をおいて再度お試しください。",
+};
 
 function formatDate(value: string): string {
   if (value === "") return "—";
@@ -67,6 +91,9 @@ export function ApiKeysListPresenter({
           <TableHead>API キー</TableHead>
           <TableHead>作成日</TableHead>
           <TableHead>有効期限</TableHead>
+          <TableHead className="w-0">
+            <span className="sr-only">操作</span>
+          </TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -93,9 +120,88 @@ export function ApiKeysListPresenter({
                 formatExpiredAt(apiKey.expiredAt)
               )}
             </TableCell>
+            <TableCell className="text-right">
+              {disabled ? (
+                <Skeleton className="h-8 w-16" />
+              ) : (
+                <DeleteApiKeyButton apiKey={apiKey} />
+              )}
+            </TableCell>
           </TableRow>
         ))}
       </TableBody>
     </Table>
+  );
+}
+
+interface DeleteApiKeyButtonProps {
+  apiKey: ApiKey;
+}
+
+function DeleteApiKeyButton({
+  apiKey,
+}: DeleteApiKeyButtonProps): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const [errorCode, setErrorCode] = useState<DeleteApiKeyErrorCode | null>(
+    null,
+  );
+  const [isPending, startTransition] = useTransition();
+
+  const handleConfirm = (): void => {
+    setErrorCode(null);
+    startTransition(async () => {
+      const result = await deleteApiKey(apiKey.apiKeyId);
+      if (result.success) {
+        setOpen(false);
+        return;
+      }
+      setErrorCode(result.code);
+    });
+  };
+
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        if (!nextOpen) setErrorCode(null);
+      }}
+    >
+      <AlertDialogTrigger
+        render={
+          <Button type="button" variant="outline" size="sm">
+            削除
+          </Button>
+        }
+      />
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>API キーを削除しますか？</AlertDialogTitle>
+          <AlertDialogDescription>
+            {formatApiKey(apiKey.suffix)} を削除すると、このキーを使用している
+            連携はすべて無効になります。この操作は取り消せません。
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        {errorCode !== null && (
+          <p
+            role="alert"
+            className="border-destructive bg-destructive/10 text-destructive border px-3 py-2 text-sm"
+          >
+            {deleteErrorMessages[errorCode]}
+          </p>
+        )}
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>キャンセル</AlertDialogCancel>
+          <AlertDialogAction
+            type="button"
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={isPending}
+          >
+            {isPending ? "削除中..." : "削除する"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }

--- a/apps/web/app/(main)/settings/api-keys/delete-api-key.action.small.server.test.ts
+++ b/apps/web/app/(main)/settings/api-keys/delete-api-key.action.small.server.test.ts
@@ -1,0 +1,131 @@
+import { expect, test as base, vi } from "vitest";
+import { deleteApiKey } from "./delete-api-key.action";
+
+const getSessionMock = vi.fn<() => Promise<{ data: { session: unknown } }>>();
+const revalidatePathMock = vi.fn<(path: string) => void>();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    auth: { getSession: getSessionMock },
+  }),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: (path: string) => revalidatePathMock(path),
+}));
+
+const test = base.extend<{ deleteApiKey: typeof deleteApiKey }>({
+  deleteApiKey: async ({}, provide) => {
+    getSessionMock.mockReset();
+    revalidatePathMock.mockReset();
+    vi.unstubAllGlobals();
+    await provide(deleteApiKey);
+  },
+});
+
+test("session が無い場合は UNAUTHORIZED コードを返す", async ({
+  deleteApiKey,
+}) => {
+  getSessionMock.mockResolvedValue({ data: { session: null } });
+
+  const result = await deleteApiKey("apikey-1");
+
+  expect(result).toEqual({ success: false, code: "UNAUTHORIZED" });
+});
+
+test("API が 401 を返した場合は UNAUTHORIZED コードを返す", async ({
+  deleteApiKey,
+}) => {
+  getSessionMock.mockResolvedValue({
+    data: {
+      session: { user: { id: "user-1" }, access_token: "token-1" },
+    },
+  });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => new Response(null, { status: 401 })),
+  );
+
+  const result = await deleteApiKey("apikey-1");
+
+  expect(result).toEqual({ success: false, code: "UNAUTHORIZED" });
+});
+
+test("API が 404 を返した場合は APIKEY_NOT_FOUND コードを返す", async ({
+  deleteApiKey,
+}) => {
+  getSessionMock.mockResolvedValue({
+    data: {
+      session: { user: { id: "user-1" }, access_token: "token-1" },
+    },
+  });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => new Response(null, { status: 404 })),
+  );
+
+  const result = await deleteApiKey("apikey-1");
+
+  expect(result).toEqual({ success: false, code: "APIKEY_NOT_FOUND" });
+});
+
+test("API がその他のエラーを返した場合は INTERNAL_ERROR コードを返す", async ({
+  deleteApiKey,
+}) => {
+  getSessionMock.mockResolvedValue({
+    data: {
+      session: { user: { id: "user-1" }, access_token: "token-1" },
+    },
+  });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => new Response(null, { status: 500 })),
+  );
+
+  const result = await deleteApiKey("apikey-1");
+
+  expect(result).toEqual({ success: false, code: "INTERNAL_ERROR" });
+});
+
+test("API が 204 を返した場合は success を返し revalidatePath を呼ぶ", async ({
+  deleteApiKey,
+}) => {
+  getSessionMock.mockResolvedValue({
+    data: {
+      session: { user: { id: "user-1" }, access_token: "token-1" },
+    },
+  });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => new Response(null, { status: 204 })),
+  );
+
+  const result = await deleteApiKey("apikey-1");
+
+  expect(result).toEqual({ success: true });
+  expect(revalidatePathMock).toHaveBeenCalledWith("/settings/api-keys");
+});
+
+test("API URL に apiKeyId が組み立てられ、Authorization ヘッダーが設定される", async ({
+  deleteApiKey,
+}) => {
+  getSessionMock.mockResolvedValue({
+    data: {
+      session: { user: { id: "user-xyz" }, access_token: "token-xyz" },
+    },
+  });
+  const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+  vi.stubGlobal("fetch", fetchMock);
+
+  await deleteApiKey("11111111-1111-1111-1111-111111111111");
+
+  expect(fetchMock).toHaveBeenCalledWith(
+    `${process.env.API_URL}/v1/me/apikeys/11111111-1111-1111-1111-111111111111`,
+    {
+      method: "DELETE",
+      headers: {
+        Authorization: "Bearer token-xyz",
+      },
+    },
+  );
+});

--- a/apps/web/app/(main)/settings/api-keys/delete-api-key.action.ts
+++ b/apps/web/app/(main)/settings/api-keys/delete-api-key.action.ts
@@ -1,0 +1,52 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+
+export type DeleteApiKeyErrorCode =
+  | "UNAUTHORIZED"
+  | "APIKEY_NOT_FOUND"
+  | "INTERNAL_ERROR";
+
+export type DeleteApiKeyResult =
+  | { success: true }
+  | { success: false; code: DeleteApiKeyErrorCode };
+
+export async function deleteApiKey(
+  apiKeyId: string,
+): Promise<DeleteApiKeyResult> {
+  const supabase = await createClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    return { success: false, code: "UNAUTHORIZED" };
+  }
+
+  const response = await fetch(
+    `${process.env.API_URL}/v1/me/apikeys/${encodeURIComponent(apiKeyId)}`,
+    {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${session.access_token}`,
+      },
+    },
+  );
+
+  if (response.status === 401) {
+    return { success: false, code: "UNAUTHORIZED" };
+  }
+
+  if (response.status === 404) {
+    return { success: false, code: "APIKEY_NOT_FOUND" };
+  }
+
+  if (!response.ok) {
+    return { success: false, code: "INTERNAL_ERROR" };
+  }
+
+  revalidatePath("/settings/api-keys");
+
+  return { success: true };
+}

--- a/apps/web/components/ui/alert-dialog.tsx
+++ b/apps/web/components/ui/alert-dialog.tsx
@@ -1,0 +1,187 @@
+"use client"
+
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog"
+
+import { cn } from "@/lib/utilities"
+import { Button } from "@/components/ui/button"
+
+function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: AlertDialogPrimitive.Backdrop.Props) {
+  return (
+    <AlertDialogPrimitive.Backdrop
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/80 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Popup.Props & {
+  size?: "default" | "sm"
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Popup
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-3 rounded-xl bg-popover p-4 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-64 data-[size=default]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogMedia({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "mb-2 inline-flex size-8 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "font-heading text-sm font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn(
+        "text-xs/relaxed text-balance text-muted-foreground md:text-pretty *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  return (
+    <Button
+      data-slot="alert-dialog-action"
+      className={cn(className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Close.Props &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-cancel"
+      className={cn(className)}
+      render={<Button variant={variant} size={size} />}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -6,16 +6,16 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utilities";
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding font-sans font-bold text-sm uppercase tracking-widest whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 active:not-aria-[haspopup]:translate-y-px aria-disabled:pointer-events-none aria-disabled:opacity-30 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center border border-transparent bg-clip-padding font-sans font-bold text-sm uppercase tracking-widest whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 active:not-aria-[haspopup]:translate-y-px aria-disabled:pointer-events-none aria-disabled:opacity-30 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
         default:
-          "relative bg-transparent border border-primary text-primary transition-all duration-350 ease-in overflow-hidden cursor-pointer rounded-none h-auto before:content-[''] before:absolute before:inset-0 before:bg-primary before:scale-x-0 before:origin-left before:transition-transform before:duration-350 before:ease-in before:z-0 hover:before:scale-x-100 hover:text-background hover:shadow-[0_0_16px_oklch(0.75_0.12_77/0.3)]",
+          "relative bg-transparent border border-primary text-primary transition-all duration-350 ease-in overflow-hidden cursor-pointer h-auto before:content-[''] before:absolute before:inset-0 before:bg-primary before:scale-x-0 before:origin-left before:transition-transform before:duration-350 before:ease-in before:z-0 hover:before:scale-x-100 hover:text-background hover:shadow-[0_0_16px_oklch(0.75_0.12_77/0.3)]",
         outline:
-          "relative bg-transparent border border-border text-muted-foreground transition-all duration-300 ease-in cursor-pointer rounded-none h-auto hover:border-foreground hover:text-foreground",
+          "relative bg-transparent border border-border text-muted-foreground transition-all duration-300 ease-in cursor-pointer h-auto hover:border-foreground hover:text-foreground",
         secondary:
-          "relative bg-transparent border border-secondary text-secondary transition-all duration-350 ease-in overflow-hidden cursor-pointer rounded-none h-auto before:content-[''] before:absolute before:inset-0 before:bg-secondary before:scale-x-0 before:origin-left before:transition-transform before:duration-350 before:ease-in before:z-0 hover:before:scale-x-100 hover:text-secondary-foreground hover:shadow-[0_0_16px_oklch(0.72_0.09_190/0.3)]",
+          "relative bg-transparent border border-secondary text-secondary transition-all duration-350 ease-in overflow-hidden cursor-pointer h-auto before:content-[''] before:absolute before:inset-0 before:bg-secondary before:scale-x-0 before:origin-left before:transition-transform before:duration-350 before:ease-in before:z-0 hover:before:scale-x-100 hover:text-secondary-foreground hover:shadow-[0_0_16px_oklch(0.72_0.09_190/0.3)]",
         ghost:
           "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground",
         destructive:

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -6,16 +6,16 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utilities";
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center border border-transparent bg-clip-padding font-sans font-bold text-sm uppercase tracking-widest whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 active:not-aria-[haspopup]:translate-y-px aria-disabled:pointer-events-none aria-disabled:opacity-30 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding font-sans font-bold text-sm uppercase tracking-widest whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 active:not-aria-[haspopup]:translate-y-px aria-disabled:pointer-events-none aria-disabled:opacity-30 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
         default:
-          "relative bg-transparent border border-primary text-primary transition-all duration-350 ease-in overflow-hidden cursor-pointer h-auto before:content-[''] before:absolute before:inset-0 before:bg-primary before:scale-x-0 before:origin-left before:transition-transform before:duration-350 before:ease-in before:z-0 hover:before:scale-x-100 hover:text-background hover:shadow-[0_0_16px_oklch(0.75_0.12_77/0.3)]",
+          "relative bg-transparent border border-primary text-primary transition-all duration-350 ease-in overflow-hidden cursor-pointer rounded-none h-auto before:content-[''] before:absolute before:inset-0 before:bg-primary before:scale-x-0 before:origin-left before:transition-transform before:duration-350 before:ease-in before:z-0 hover:before:scale-x-100 hover:text-background hover:shadow-[0_0_16px_oklch(0.75_0.12_77/0.3)]",
         outline:
-          "relative bg-transparent border border-border text-muted-foreground transition-all duration-300 ease-in cursor-pointer h-auto hover:border-foreground hover:text-foreground",
+          "relative bg-transparent border border-border text-muted-foreground transition-all duration-300 ease-in cursor-pointer rounded-none h-auto hover:border-foreground hover:text-foreground",
         secondary:
-          "relative bg-transparent border border-secondary text-secondary transition-all duration-350 ease-in overflow-hidden cursor-pointer h-auto before:content-[''] before:absolute before:inset-0 before:bg-secondary before:scale-x-0 before:origin-left before:transition-transform before:duration-350 before:ease-in before:z-0 hover:before:scale-x-100 hover:text-secondary-foreground hover:shadow-[0_0_16px_oklch(0.72_0.09_190/0.3)]",
+          "relative bg-transparent border border-secondary text-secondary transition-all duration-350 ease-in overflow-hidden cursor-pointer rounded-none h-auto before:content-[''] before:absolute before:inset-0 before:bg-secondary before:scale-x-0 before:origin-left before:transition-transform before:duration-350 before:ease-in before:z-0 hover:before:scale-x-100 hover:text-secondary-foreground hover:shadow-[0_0_16px_oklch(0.72_0.09_190/0.3)]",
         ghost:
           "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground",
         destructive:

--- a/apps/web/vitest.client.config.ts
+++ b/apps/web/vitest.client.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     include: [
       "@hugeicons/core-free-icons",
       "@hugeicons/react",
+      "@base-ui/react/alert-dialog",
       "@base-ui/react/button",
       "@base-ui/react/input",
       "@base-ui/react/merge-props",

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
         "app/(main)/settings/api-keys/api-keys.data.ts",
         "app/(main)/settings/api-keys/handle-list-api-keys-result.server.ts",
         "app/(main)/settings/api-keys/generate-api-key.action.ts",
+        "app/(main)/settings/api-keys/delete-api-key.action.ts",
         "app/(main)/settings/api-keys/generate-api-key.presenter.client.tsx",
         "app/(main)/_components/header-search.universal.tsx",
         "app/(main)/_top-page/featured-courses.data.ts",


### PR DESCRIPTION
## Summary

- `/settings/api-keys` の各行から API キーを削除できるようにする（確認ダイアログ付き、shadcn/ui の AlertDialog ベース）
- バックエンドに `DELETE /v1/me/apikeys/{apikeyID}` を追加。`apikey_id` + `user_id` の AND 条件で他人のキーは絶対に削除されない（影響行数 0 のとき 404 `APIKEY_NOT_FOUND`）
- 既存パターン（`/v1/me/...` + auth middleware）に合わせて userID は JWT context から取得

## 設計メモ

- **物理削除**を採用（apikey は plain_suffix と expired_at しかメタ情報がなく、復元の業務要求もないため）
- Command なのでハンドラー → usecase → repository 構成。 `apiKeyQuerier` を `ApiKeySqrcRepository` に注入し、`deleteByID(userID, apiKeyID)` を追加
- 削除フロー全体（dialog 開閉 → action 呼び出し → 一覧再取得）は base-ui 内部の inert layer の都合で vitest browser モードでクリックが阻まれるため、unit test では dialog 表示のみ確認し、フロー全体は E2E に委譲

## Test plan

- [x] make api-test-all パス（カバレッジ 83.8%）
- [x] make web-test-all パス（カバレッジ 88.88%）
- [x] make web-lint パス
- [x] make spell-check パス
- [ ] ブラウザでの動作確認（自分の API キーが削除できる / 削除後に一覧から消える）
- [ ] E2E（DB リセット後）で削除フロー全体を担保

ClickUp: https://app.clickup.com/t/86excr3rj

🤖 Generated with [Claude Code](https://claude.com/claude-code)